### PR TITLE
Assorted improvements

### DIFF
--- a/Importers/Referrers/RecordImporter.php
+++ b/Importers/Referrers/RecordImporter.php
@@ -132,6 +132,9 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
             }
 
             $keyword = $row->getMetadata('ga:keyword');
+            if (empty($keyword)) {
+                $keyword = self::NOT_SET_IN_GA_LABEL;
+            }
 
             $this->campaignKeywords[$keyword] = true;
 

--- a/Tasks.php
+++ b/Tasks.php
@@ -91,7 +91,7 @@ class Tasks extends \Piwik\Plugin\Tasks
         }
 
         $cliPhp = new CliPhp();
-        $phpBinary = $cliPhp->findPhpBinary();
+        $phpBinary = $cliPhp->findPhpBinary() ?: 'php';
 
         $command = "nohup $phpBinary " . PIWIK_INCLUDE_PATH . '/console ';
         if (!empty($hostname)) {
@@ -171,7 +171,10 @@ class Tasks extends \Piwik\Plugin\Tasks
             $pathToConsole = '/tests/PHPUnit/proxy/console';
         }
 
-        $command = self::DATE_FINISHED_ENV_VAR . '=' . $lastDateImported->toString() . " nohup php " . PIWIK_INCLUDE_PATH . $pathToConsole . ' ';
+        $cliPhp = new CliPhp();
+        $phpBinary = $cliPhp->findPhpBinary() ?: 'php';
+
+        $command = self::DATE_FINISHED_ENV_VAR . '=' . $lastDateImported->toString() . " nohup $phpBinary " . PIWIK_INCLUDE_PATH . $pathToConsole . ' ';
         if (!empty($hostname)) {
             $command .= '--matomo-domain=' . escapeshellarg($hostname) . ' ';
         }


### PR DESCRIPTION
Refs #14 

* Add --skip-archiving option to allow avoiding launching of archiving command when importing.
* Default empty keyword value when importing campaign keyword report.
* Use CliPhp to determine php binary and default to just `php` if not found.