### PR TITLE
Fix issue in importing when website has URLs that end in the default action name

### DIFF
--- a/Google/SearchEngineMapper.php
+++ b/Google/SearchEngineMapper.php
@@ -40,6 +40,9 @@ class SearchEngineMapper
         $this->sourcesToSearchEngines['images.google'] = $this->sourcesToSearchEngines['google images'];
         $this->sourcesToSearchEngines['incredimail'] = $this->sourcesToSearchEngines['google'];
         $this->sourcesToSearchEngines['alice'] = $this->sourcesToSearchEngines['yandex'];
+        $this->sourcesToSearchEngines['live'] = $this->sourcesToSearchEngines['bing'];
+        $this->sourcesToSearchEngines['msn'] = $this->sourcesToSearchEngines['bing'];
+        $this->sourcesToSearchEngines['search'] = $this->sourcesToSearchEngines['ask'];
         $this->sourcesToSearchEngines['avg'] = ['name' => 'xx']; // TODO: not detected by matomo
     }
 

--- a/Importer.php
+++ b/Importer.php
@@ -321,6 +321,7 @@ class Importer
         $archiveWriter = $this->makeArchiveWriter($site, $date, $segment, $plugin);
         $archiveWriter->initNewArchive();
 
+        $recordInserter = new RecordInserter($archiveWriter);
 
         foreach ($recordImporters as $plugin => $recordImporter) {
             $this->logger->debug("Importing data for the {plugin} plugin.", [
@@ -330,7 +331,7 @@ class Importer
             // TODO: change visitor frequency importer
             // TODO: if two record importers use the same segment, this will likely break (since one archive will have metrics for one plugin, another archive for another plugin, so queries won't get the full data)
 
-            $recordImporter->setArchiveWriter($archiveWriter);
+            $recordImporter->setRecordInserter($recordInserter);
             $recordImporter->importRecords($date);
 
             // since we recorded some data, at some time, remove the no data message

--- a/Importers/CustomDimensions/RecordImporter.php
+++ b/Importers/CustomDimensions/RecordImporter.php
@@ -83,7 +83,7 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
         Common::destroy($table);
 
         // if scope is action, we also need to query exit page metrics and visit metrics (done separately
-        // see RecordImporter::getPageMetrics for more info)
+        // see Importers::getPageMetrics for more info)
         if ($dimensionObj['scope'] === CustomDimensions::SCOPE_ACTION) {
             $table = $gaQuery->query($day, $dimensions = [$dimension], [Metrics::INDEX_NB_VISITS, Metrics::INDEX_BOUNCE_COUNT], [
                 'orderBys' => [

--- a/Importers/Referrers/RecordImporter.php
+++ b/Importers/Referrers/RecordImporter.php
@@ -170,6 +170,12 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
             // URLs don't have protocols in GA
             $referrerUrl = 'http://' . $referrerUrl;
 
+            // URLs can have extra information appended towards the end (like, ' iphone') in old data
+            $parts = explode(' ', $referrerUrl);
+            if (count($parts) == 2) {
+                $referrerUrl = $parts[0];
+            }
+
             // skip if this isn't a URL
             if (!filter_var($referrerUrl, FILTER_VALIDATE_URL)) {
                 $this->getLogger()->warning("Non referrer URL encountered: $referrerUrl");

--- a/RecordInserter.php
+++ b/RecordInserter.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter;
+
+
+use Piwik\DataAccess\ArchiveWriter;
+use Piwik\DataTable;
+use Piwik\Metrics;
+
+class RecordInserter
+{
+    /**
+     * @var ArchiveWriter
+     */
+    private $archiveWriter;
+
+    public function __construct(ArchiveWriter $writer)
+    {
+        $this->archiveWriter = $writer;
+    }
+
+    public function insertRecord($recordName, DataTable $record, $maximumRowsInDataTable = null,
+                                    $maximumRowsInSubDataTable = null, $columnToSortByBeforeTruncation = null)
+    {
+        $record->setMetadata(RecordImporter::IS_IMPORTED_FROM_GOOGLE_METADATA_NAME, 1);
+
+        $blob = $record->getSerialized($maximumRowsInDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
+        $this->insertBlobRecord($recordName, $blob);
+    }
+
+    public function insertBlobRecord($name, $values)
+    {
+        $this->archiveWriter->insertBlobRecord($name, $values);
+    }
+
+    public function insertNumericRecords(array $values)
+    {
+        foreach ($values as $name => $value) {
+            if (is_numeric($name)) {
+                $name = Metrics::getReadableColumnName($name);
+            }
+            $this->archiveWriter->insertRecord($name, $value);
+        }
+    }
+}

--- a/tests/Framework/BaseRecordImporterTest.php
+++ b/tests/Framework/BaseRecordImporterTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\tests\Framework;
+
+
+use Piwik\DataTable;
+use Piwik\DataTable\Map;
+use Piwik\DataTable\Renderer\Xml;
+use Piwik\Date;
+use Piwik\Plugins\GoogleAnalyticsImporter\GoogleAnalyticsQueryService;
+use Piwik\Plugins\GoogleAnalyticsImporter\Importers\Actions\RecordImporter;
+use Piwik\Plugins\GoogleAnalyticsImporter\RecordInserter;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Psr\Log\NullLogger;
+
+abstract class BaseRecordImporterTest extends IntegrationTestCase
+{
+    /**
+     * @var Map
+     */
+    protected $capturedReports;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2010-02-01 00:00:00');
+    }
+
+    abstract function getTestDir();
+
+    protected function runImporterTest($testName, $mockGaResponses, $idSite = 1)
+    {
+        $this->capturedReports = new Map();
+        $this->capturedReports->setKeyName('record');
+
+        $mockGaQuery = $this->makeMockGaQuery($mockGaResponses);
+        $instance = new RecordImporter($mockGaQuery, $idSite, new NullLogger());
+        $instance->setRecordInserter($this->makeMockRecordInserter());
+
+        $instance->importRecords(Date::factory('2013-02-03'));
+
+        $this->checkCapturedReports($testName);
+    }
+
+    protected function makeMockGaQuery($responses)
+    {
+        $mock = $this->getMock(GoogleAnalyticsQueryService::class, ['query'], [], '', $callOriginalConstructor = false);
+        $mock->method('query')
+            ->willReturnCallback(function () use (&$responses) {
+                if (empty($responses)) {
+                    throw new \Exception("out of mock GA responses");
+                }
+
+                $rows = array_shift($responses);
+                $result = new DataTable();
+                foreach ($rows as $row) {
+                    $newRow = new DataTable\Row();
+                    foreach ($row as $name => $value) {
+                        if (is_numeric($name)) {
+                            $newRow->setColumn($name, $value);
+                        } else {
+                            $newRow->setMetadata($name, $value);
+                        }
+                    }
+                    $result->addRow($newRow);
+                }
+                return $result;
+            });
+
+        /** @var GoogleAnalyticsQueryService $instance */
+        $instance = $mock;
+        return $instance;
+    }
+
+    protected function makeMockRecordInserter()
+    {
+        $mock = $this->getMock(RecordInserter::class, ['insertNumericRecords', 'insertRecord'], [], '', $callOriginalConstructor = false);
+        $mock->method('insertNumericRecords')
+            ->willReturnCallback(function ($values) {
+                foreach ($values as $name => $value) {
+                    $table = new DataTable();
+                    $table->addRowFromSimpleArray(['value' => $value]);
+                    $this->capturedReports->addTable($table, $name);
+                }
+            });
+        $mock->method('insertRecord')
+            ->willReturnCallback(function ($recordName, DataTable $record, $maximumRowsInDataTable = null,
+                                           $maximumRowsInSubDataTable = null, $columnToSortByBeforeTruncation = null) {
+                $clone = $this->copyDataTable($record);
+                $this->capturedReports->addTable($clone, $recordName);
+            });
+
+        /** @var RecordInserter $inserter */
+        $inserter = $mock;
+        return $inserter;
+    }
+
+    protected function checkCapturedReports($testName)
+    {
+        $testName = $this->getTestedPluginName() . '_' . $testName;
+
+        $testFilesDirectory = $this->getTestDir() . '/..';
+        $expectedFilePath = $testFilesDirectory . '/expected/' . $testName . '.xml';
+        $processedFilePath = $testFilesDirectory . '/processed/' . $testName . '.xml';
+
+        $renderer = new Xml();
+        $renderer->setTable($this->capturedReports);
+        $renderer->setRenderSubTables(true);
+        $result = $renderer->render();
+
+        file_put_contents($processedFilePath, $result);
+
+        $expectedContents = file_get_contents($expectedFilePath);
+        $this->assertEquals($expectedContents, $result);
+    }
+
+    protected function getTestedPluginName()
+    {
+        return 'Actions';
+    }
+
+    private function copyDataTable(DataTable $record)
+    {
+        $result = new DataTable();
+        foreach ($record->getRows() as $row) {
+            $clone = clone $row;
+
+            $subtable = $row->getSubtable();
+            if ($subtable) {
+                $clone->setSubtable($this->copyDataTable($subtable));
+            }
+
+            $result->addRow($clone);
+        }
+        return $result;
+    }
+}

--- a/tests/Integration/Importers/Actions/RecordImporterTest.php
+++ b/tests/Integration/Importers/Actions/RecordImporterTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\tests\Integration\Importers\Actions;
+
+use Piwik\Metrics;
+use Piwik\Plugins\GoogleAnalyticsImporter\tests\Framework\BaseRecordImporterTest;
+
+class RecordImporterTest extends BaseRecordImporterTest
+{
+    public function test_basicImport()
+    {
+        $this->runImporterTest('basicImport', [
+            $this->makeMockPageUrlsResponse(),
+            $this->makeMockPageUrlsVisitsRespone(),
+            $this->makeMockPageTitlesResponse(),
+            $this->makeMockPageTitlesVisitsResponse(),
+            $this->makeMockEntryPageUrlsResponse(),
+            $this->makeMockEntryPageTItlesResponse(),
+            $this->makeMockExitPageUrlsResponse(),
+            $this->makeMockExitPageTItlesResponse(),
+            $this->makeMockSearchKeywordsResponse(),
+        ]);
+    }
+
+    public function getTestDir()
+    {
+        return __DIR__;
+    }
+
+    private function makeMockPageUrlsResponse()
+    {
+        return [
+            [
+                'ga:pagePath' => '/',
+                Metrics::INDEX_PAGE_NB_HITS => 24,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 10,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 3,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 4,
+            ],
+            [
+                'ga:pagePath' => '/index',
+                Metrics::INDEX_PAGE_NB_HITS => 18,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 10,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 3,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 4,
+            ],
+            [
+                'ga:pagePath' => '/apage',
+                Metrics::INDEX_PAGE_NB_HITS => 10,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 5,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 2,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 6,
+            ],
+            [
+                'ga:pagePath' => '/folder/page',
+                Metrics::INDEX_PAGE_NB_HITS => 9,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 10,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 2,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 1,
+            ],
+        ];
+    }
+
+    private function makeMockPageUrlsVisitsRespone()
+    {
+        return [
+            [
+                'ga:pagePath' => '/apage',
+                Metrics::INDEX_NB_VISITS => 14,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 4,
+            ],
+            [
+                'ga:pagePath' => '/folder/page',
+                Metrics::INDEX_NB_VISITS => 7,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 7,
+            ],
+            [
+                'ga:pagePath' => '/index',
+                Metrics::INDEX_NB_VISITS => 6,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 5,
+            ],
+            [
+                'ga:pagePath' => '/',
+                Metrics::INDEX_NB_VISITS => 1,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 2,
+            ],
+        ];
+    }
+
+    private function makeMockPageTitlesResponse()
+    {
+        return [
+            [
+                'ga:pagePath' => '/',
+                'ga:pageTitle' => 'Index real',
+                Metrics::INDEX_PAGE_NB_HITS => 19,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 2,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 5,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 7,
+            ],
+            [
+                'ga:pagePath' => '/apage',
+                'ga:pageTitle' => 'A Page',
+                Metrics::INDEX_PAGE_NB_HITS => 18,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 1,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 2,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 4,
+            ],
+            [
+                'ga:pagePath' => '/index',
+                'ga:pageTitle' => 'Index page',
+                Metrics::INDEX_PAGE_NB_HITS => 2,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 2,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 3,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 3,
+            ],
+            [
+                'ga:pagePath' => '/folder/page',
+                'ga:pageTitle' => 'A Folder > Page',
+                Metrics::INDEX_PAGE_NB_HITS => 1,
+                Metrics::INDEX_PAGE_SUM_TIME_SPENT => 1,
+                Metrics::INDEX_PAGE_SUM_TIME_GENERATION => 1,
+                Metrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION => 1,
+            ],
+        ];
+    }
+
+    private function makeMockPageTitlesVisitsResponse()
+    {
+        return [
+            [
+                'ga:pageTitle' => 'A Page',
+                Metrics::INDEX_NB_VISITS => 16,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 15,
+            ],
+            [
+                'ga:pageTitle' => 'A Folder > Page',
+                Metrics::INDEX_NB_VISITS => 20,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 10,
+            ],
+            [
+                'ga:pageTitle' => 'Index real',
+                Metrics::INDEX_NB_VISITS => 3,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 9,
+            ],
+            [
+                'ga:pageTitle' => 'Index page',
+                Metrics::INDEX_NB_VISITS => 14,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 7,
+            ],
+        ];
+    }
+
+    private function makeMockEntryPageUrlsResponse()
+    {
+        return [
+            [
+                'ga:landingPagePath' => '/index',
+                Metrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 7,
+                Metrics::INDEX_PAGE_ENTRY_NB_VISITS => 8,
+                Metrics::INDEX_PAGE_ENTRY_NB_ACTIONS => 9,
+                Metrics::INDEX_PAGE_ENTRY_SUM_VISIT_LENGTH => 10,
+                Metrics::INDEX_PAGE_ENTRY_BOUNCE_COUNT => 11,
+            ],
+            [
+                'ga:landingPagePath' => '/',
+                Metrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 2,
+                Metrics::INDEX_PAGE_ENTRY_NB_VISITS => 3,
+                Metrics::INDEX_PAGE_ENTRY_NB_ACTIONS => 4,
+                Metrics::INDEX_PAGE_ENTRY_SUM_VISIT_LENGTH => 5,
+                Metrics::INDEX_PAGE_ENTRY_BOUNCE_COUNT => 6,
+            ],
+        ];
+    }
+
+    private function makeMockEntryPageTItlesResponse()
+    {
+        return [
+            [
+                'ga:pageTitle' => 'Index page',
+                Metrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 7,
+                Metrics::INDEX_PAGE_ENTRY_NB_VISITS => 8,
+                Metrics::INDEX_PAGE_ENTRY_NB_ACTIONS => 9,
+                Metrics::INDEX_PAGE_ENTRY_SUM_VISIT_LENGTH => 10,
+                Metrics::INDEX_PAGE_ENTRY_BOUNCE_COUNT => 11,
+            ],
+            [
+                'ga:pageTitle' => 'Index real',
+                Metrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 2,
+                Metrics::INDEX_PAGE_ENTRY_NB_VISITS => 3,
+                Metrics::INDEX_PAGE_ENTRY_NB_ACTIONS => 4,
+                Metrics::INDEX_PAGE_ENTRY_SUM_VISIT_LENGTH => 5,
+                Metrics::INDEX_PAGE_ENTRY_BOUNCE_COUNT => 6,
+            ],
+        ];
+    }
+
+    private function makeMockExitPageUrlsResponse()
+    {
+        return [
+            [
+                'ga:landingPagePath' => '/',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 4,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 4,
+            ],
+            [
+                'ga:landingPagePath' => '/index',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 2,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 2,
+            ],
+            [
+                'ga:landingPagePath' => '/folder/page',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 1,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 1,
+            ],
+        ];
+    }
+
+    private function makeMockExitPageTItlesResponse()
+    {
+        return [
+            [
+                'ga:pageTitle' => 'Index real',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 4,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 4,
+            ],
+            [
+                'ga:pageTitle' => 'Index page',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 2,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 2,
+            ],
+            [
+                'ga:pageTitle' => 'A Folder > Page',
+                Metrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 1,
+                Metrics::INDEX_PAGE_EXIT_NB_VISITS => 1,
+            ],
+        ];
+    }
+
+    private function makeMockSearchKeywordsResponse()
+    {
+        return [
+            [
+                'ga:searchKeyword' => 'serach 5',
+                Metrics::INDEX_NB_VISITS => 10,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 4,
+            ],
+            [
+                'ga:searchKeyword' => 'serach 6',
+                Metrics::INDEX_NB_VISITS => 8,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 4,
+            ],
+            [
+                'ga:searchKeyword' => 'serach 2',
+                Metrics::INDEX_NB_VISITS => 1,
+                Metrics::INDEX_NB_UNIQ_VISITORS => 1,
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Importers/expected/Actions_basicImport.xml
+++ b/tests/Integration/Importers/expected/Actions_basicImport.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="Actions_actions">
+		<row>
+			<col name="label"> Index real</col>
+			<col name="2">3</col>
+			<col name="1">9</col>
+			<col name="12">19</col>
+			<col name="13">2</col>
+			<col name="30">5</col>
+			<col name="31">7</col>
+			<col name="17">2</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="14">4</col>
+			<col name="15">4</col>
+		</row>
+		<row>
+			<col name="label"> A Page</col>
+			<col name="2">16</col>
+			<col name="1">15</col>
+			<col name="12">18</col>
+			<col name="13">1</col>
+			<col name="30">2</col>
+			<col name="31">4</col>
+		</row>
+		<row>
+			<col name="label"> Index page</col>
+			<col name="2">14</col>
+			<col name="1">7</col>
+			<col name="12">2</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">3</col>
+			<col name="17">7</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="14">2</col>
+			<col name="15">2</col>
+		</row>
+		<row>
+			<col name="label"> A Folder &gt; Page</col>
+			<col name="2">20</col>
+			<col name="1">10</col>
+			<col name="12">1</col>
+			<col name="13">1</col>
+			<col name="30">1</col>
+			<col name="31">1</col>
+			<col name="14">1</col>
+			<col name="15">1</col>
+		</row>
+	</result>
+	<result record="Actions_actions_url">
+		<row>
+			<col name="label">/index</col>
+			<col name="2">1</col>
+			<col name="1">2</col>
+			<col name="12">24</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="17">2</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="url">http://piwik.net/</col>
+		</row>
+		<row>
+			<col name="label">/index</col>
+			<col name="2">6</col>
+			<col name="1">5</col>
+			<col name="12">18</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="17">7</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="url">http://piwik.net/index</col>
+		</row>
+		<row>
+			<col name="label">/apage</col>
+			<col name="2">14</col>
+			<col name="1">4</col>
+			<col name="12">10</col>
+			<col name="13">5</col>
+			<col name="30">2</col>
+			<col name="31">6</col>
+			<col name="url">http://piwik.net/apage</col>
+		</row>
+		<row>
+			<col name="label">folder</col>
+			<col name="2">7</col>
+			<col name="12">9</col>
+			<col name="13">10</col>
+			<col name="30">2</col>
+			<col name="31">1</col>
+			<col name="folder_url_start">folder</col>
+			<col name="idsubdatatable">16</col>
+			<col name="subtable">
+				<row>
+					<col name="label">/page</col>
+					<col name="2">7</col>
+					<col name="1">7</col>
+					<col name="12">9</col>
+					<col name="13">10</col>
+					<col name="30">2</col>
+					<col name="31">1</col>
+					<col name="url">http://piwik.net/folder/page</col>
+				</row>
+			</col>
+		</row>
+	</result>
+	<result record="Actions_sitesearch">
+		<row>
+			<col name="label">serach 5</col>
+			<col name="2">10</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 6</col>
+			<col name="2">8</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 2</col>
+			<col name="2">1</col>
+			<col name="1">1</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+	</result>
+	<result record="Actions_nb_pageviews">
+		<row>
+			<value>61</value>
+		</row>
+	</result>
+	<result record="Actions_nb_uniq_pageviews">
+		<row>
+			<value>28</value>
+		</row>
+	</result>
+	<result record="Actions_sum_time_generation">
+		<row>
+			<value>10</value>
+		</row>
+	</result>
+	<result record="Actions_nb_hits_with_time_generation">
+		<row>
+			<value>15</value>
+		</row>
+	</result>
+	<result record="Actions_nb_searches">
+		<row>
+			<value>0</value>
+		</row>
+	</result>
+	<result record="Actions_nb_keywords">
+		<row>
+			<value>3</value>
+		</row>
+	</result>
+</results>

--- a/tests/Integration/Importers/processed/Actions_basicImport.xml
+++ b/tests/Integration/Importers/processed/Actions_basicImport.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="Actions_actions">
+		<row>
+			<col name="label"> Index real</col>
+			<col name="2">3</col>
+			<col name="1">9</col>
+			<col name="12">19</col>
+			<col name="13">2</col>
+			<col name="30">5</col>
+			<col name="31">7</col>
+			<col name="17">2</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="14">4</col>
+			<col name="15">4</col>
+		</row>
+		<row>
+			<col name="label"> A Page</col>
+			<col name="2">16</col>
+			<col name="1">15</col>
+			<col name="12">18</col>
+			<col name="13">1</col>
+			<col name="30">2</col>
+			<col name="31">4</col>
+		</row>
+		<row>
+			<col name="label"> Index page</col>
+			<col name="2">14</col>
+			<col name="1">7</col>
+			<col name="12">2</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">3</col>
+			<col name="17">7</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="14">2</col>
+			<col name="15">2</col>
+		</row>
+		<row>
+			<col name="label"> A Folder &gt; Page</col>
+			<col name="2">20</col>
+			<col name="1">10</col>
+			<col name="12">1</col>
+			<col name="13">1</col>
+			<col name="30">1</col>
+			<col name="31">1</col>
+			<col name="14">1</col>
+			<col name="15">1</col>
+		</row>
+	</result>
+	<result record="Actions_actions_url">
+		<row>
+			<col name="label">/index</col>
+			<col name="2">1</col>
+			<col name="1">2</col>
+			<col name="12">24</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="17">2</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="url">http://piwik.net/</col>
+		</row>
+		<row>
+			<col name="label">/index</col>
+			<col name="2">6</col>
+			<col name="1">5</col>
+			<col name="12">18</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="17">7</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="url">http://piwik.net/index</col>
+		</row>
+		<row>
+			<col name="label">/apage</col>
+			<col name="2">14</col>
+			<col name="1">4</col>
+			<col name="12">10</col>
+			<col name="13">5</col>
+			<col name="30">2</col>
+			<col name="31">6</col>
+			<col name="url">http://piwik.net/apage</col>
+		</row>
+		<row>
+			<col name="label">folder</col>
+			<col name="2">7</col>
+			<col name="12">9</col>
+			<col name="13">10</col>
+			<col name="30">2</col>
+			<col name="31">1</col>
+			<col name="folder_url_start">folder</col>
+			<col name="idsubdatatable">16</col>
+			<col name="subtable">
+				<row>
+					<col name="label">/page</col>
+					<col name="2">7</col>
+					<col name="1">7</col>
+					<col name="12">9</col>
+					<col name="13">10</col>
+					<col name="30">2</col>
+					<col name="31">1</col>
+					<col name="url">http://piwik.net/folder/page</col>
+				</row>
+			</col>
+		</row>
+	</result>
+	<result record="Actions_sitesearch">
+		<row>
+			<col name="label">serach 5</col>
+			<col name="2">10</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 6</col>
+			<col name="2">8</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 2</col>
+			<col name="2">1</col>
+			<col name="1">1</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+	</result>
+	<result record="Actions_nb_pageviews">
+		<row>
+			<value>61</value>
+		</row>
+	</result>
+	<result record="Actions_nb_uniq_pageviews">
+		<row>
+			<value>28</value>
+		</row>
+	</result>
+	<result record="Actions_sum_time_generation">
+		<row>
+			<value>10</value>
+		</row>
+	</result>
+	<result record="Actions_nb_hits_with_time_generation">
+		<row>
+			<value>15</value>
+		</row>
+	</result>
+	<result record="Actions_nb_searches">
+		<row>
+			<value>0</value>
+		</row>
+	</result>
+	<result record="Actions_nb_keywords">
+		<row>
+			<value>3</value>
+		</row>
+	</result>
+</results>


### PR DESCRIPTION
Matomo appends the value of the `[General] default_action_name` INI config to rows in the page URLs report for URL directories. This causes problems when a site actually has a URL with that suffix (eg, http://example.com/index). This PR handles that case.

Also included:
* some more search engine mappings 
* support for old GA referrer URLs that are appended w/ 'iphone'