### PR TITLE
Compatibility for wordpress

### DIFF
--- a/Diagnostic/RequiredFunctionsCheck.php
+++ b/Diagnostic/RequiredFunctionsCheck.php
@@ -33,7 +33,7 @@ class RequiredFunctionsCheck implements Diagnostic
     {
         $requiredFunctions = ['shell_exec', 'exec'];
 
-        $areFunctionsPresent = false;
+        $areFunctionsPresent = true;
         foreach ($requiredFunctions as $func) {
             if (!function_exists($func)) {
                 $areFunctionsPresent = false;

--- a/ImportStatus.php
+++ b/ImportStatus.php
@@ -31,9 +31,10 @@ class ImportStatus
     public function startingImport($propertyId, $accountId, $viewId, $idSite, $extraCustomDimensions = [])
     {
         try {
-            $this->getImportStatus($idSite);
-
-            throw new \Exception("An import already exists for site with ID = $idSite. Please cancel this first before starting a new one.");
+            $status = $this->getImportStatus($idSite);
+            if ($status['status'] != self::STATUS_FINISHED) {
+                throw new \Exception(Piwik::translate('GoogleAnalyticsImporter_CancelExistingImportFirst', [$idSite]));
+            }
         } catch (\Exception $ex) {
             // ignore
         }

--- a/ImportStatus.php
+++ b/ImportStatus.php
@@ -30,6 +30,14 @@ class ImportStatus
 
     public function startingImport($propertyId, $accountId, $viewId, $idSite, $extraCustomDimensions = [])
     {
+        try {
+            $this->getImportStatus($idSite);
+
+            throw new \Exception("An import already exists for site with ID = $idSite. Please cancel this first before starting a new one.");
+        } catch (\Exception $ex) {
+            // ignore
+        }
+
         $now = Date::getNowTimestamp();
         $status = [
             'status' => self::STATUS_STARTED,

--- a/Tasks.php
+++ b/Tasks.php
@@ -209,12 +209,12 @@ class Tasks extends \Piwik\Plugin\Tasks
 
     public static function getArchiveLogFile($idSite, $hostname)
     {
-        return PIWIK_INCLUDE_PATH . '/tmp/logs/gaimportlog.archive.' . $idSite . '.' . $hostname . '.log';
+        return StaticContainer::get('path.tmp') . '/logs/gaimportlog.archive.' . $idSite . '.' . $hostname . '.log';
     }
 
     public static function getImportLogFile($idSite, $hostname)
     {
-        return PIWIK_INCLUDE_PATH . '/tmp/logs/gaimportlog.' . $idSite . '.' . $hostname . '.log';
+        return StaticContainer::get('path.tmp') . '/logs/gaimportlog.' . $idSite . '.' . $hostname . '.log';
     }
 
     private static function sanitizeArg($gaDimension)

--- a/lang/en.json
+++ b/lang/en.json
@@ -54,6 +54,7 @@
     "PhpExecutableMissing": "Matomo cannot find the PHP executable. The Google Analytics Importer invokes PHP from the command line to import data. This executable must be present and accessible from PHP in order for the importer to function.",
     "NohupExecutableMissing": "Matomo cannot find the nohup executable. The Google Analytics Importer uses nohup to execute the import process so it will continue on its own after a web request finishes. This executable must be present and accessible from PHP in order for the importer to function.",
     "RequiredFunctionsCheck": "Required PHP Functions",
-    "RequiredFunctionsMissing": "Matomo cannot find the %1$s PHP functions, your host has likely disabled them. The Google Analytics Importer uses these functions to import data in the background. Without them the importer cannot function."
+    "RequiredFunctionsMissing": "Matomo cannot find the %1$s PHP functions, your host has likely disabled them. The Google Analytics Importer uses these functions to import data in the background. Without them the importer cannot function.",
+    "CancelExistingImportFirst": "An import already exists for site with ID = %1$s. Please cancel it first before starting a new one."
   }
 }

--- a/tests/Integration/ImportStatusTest.php
+++ b/tests/Integration/ImportStatusTest.php
@@ -287,6 +287,29 @@ class ImportStatusTest extends IntegrationTestCase
         ];
     }
 
+    public function test_startingImport_doesNotAllowCreatingMultipleImportsWithTheSameSite()
+    {
+        $idSite = 1;
+        $this->instance->startingImport('testprop', 'testaccount', 'testview', $idSite);
+
+        try {
+            $this->instance->startingImport('testprop', 'testaccount', 'testview', $idSite);
+            $this->fail('Exception not thrown when trying to start duplicate import.');
+        } catch (\Exception $ex) {
+            // pass
+        }
+
+        $this->instance->finishedImport($idSite);
+
+        $status = $this->getImportStatus($idSite);
+        $this->assertEquals(ImportStatus::STATUS_FINISHED, $status['status']);
+
+        $this->instance->startingImport('testprop', 'testaccount', 'testview', $idSite);
+
+        $status = $this->getImportStatus($idSite);
+        $this->assertEquals(ImportStatus::STATUS_STARTED, $status['status']);
+    }
+
     private function getImportStatus($idSite)
     {
         $optionName = ImportStatus::OPTION_NAME_PREFIX . $idSite;


### PR DESCRIPTION
- use path.tmp DI to get tmp path
- if wordpress is detected, get wordpress site ID and set creation date manually
- allow restarting import if import status already exists, but only if it is finished