### PR TITLE
Set a fixed end date for Matomo for WordPress

### DIFF
--- a/Commands/ImportReports.php
+++ b/Commands/ImportReports.php
@@ -210,7 +210,10 @@ class ImportReports extends ConsoleCommand
 
                 $output->writeln("Importing reports for date range {$startDate} - {$endDate} from GA view $viewId.");
 
-                $importer->import($idSite, $viewId, $startDate, $endDate, $lock);
+                $aborted = $importer->import($idSite, $viewId, $startDate, $endDate, $lock);
+                if ($aborted) {
+                    break;
+                }
 
                 $isReimportEntry = $index < count($dateRangesToReImport);
                 if ($isReimportEntry) {

--- a/Controller.php
+++ b/Controller.php
@@ -19,6 +19,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\GoogleAnalyticsImporter\Commands\ImportReports;
 use Piwik\Plugins\GoogleAnalyticsImporter\Google\Authorization;
 use Piwik\Plugins\MobileAppMeasurable\Type;
+use Piwik\SettingsServer;
 use Piwik\Site;
 use Piwik\Url;
 use Psr\Log\LoggerInterface;
@@ -113,6 +114,35 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         return $this->index();
     }
+
+	private function setFixedEndDateIfWordPress($endDate)
+	{
+		// if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
+		// tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
+		// otherwise it would potentially always overwrite already aggregated report data
+		if (method_exists(SettingsServer::class, 'isMatomoForWordPress')
+		    && SettingsServer::isMatomoForWordPress()
+		    && defined('\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE')) {
+
+			$installDate = get_option(\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE);
+
+			if (empty($installDate)) {
+				// matomo for WordPress was installed before this option was set
+				// we have to make sure there will be an end date otherwise it will always overwrite data
+				// we assume Matomo for WordPress was installed two days ago
+				$installDate = Date::today()->subDay(2);
+			} else {
+				// import up to 1 day before original install
+				$installDate = Date::factory($installDate)->subDay(1);
+			}
+
+			if (!$endDate || Date::factory($endDate)->isLater($installDate)) {
+				$endDate = $installDate->toString();
+			}
+        }
+
+		return $endDate;
+	}
 
     /**
      * Processes the response from google oauth service
@@ -230,6 +260,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $idSite = Common::getRequestVar('idSite', null, 'int');
             $endDate = Common::getRequestVar('endDate', '', 'string');
 
+            $endDate = $this->setFixedEndDateIfWordPress($endDate);
+
             /** @var ImportStatus $importStatus */
             $importStatus = StaticContainer::get(ImportStatus::class);
             $status = $importStatus->getImportStatus($idSite);
@@ -265,6 +297,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             }
 
             $endDate = trim(Common::getRequestVar('endDate', ''));
+	        $endDate = $this->setFixedEndDateIfWordPress($endDate);
             if (!empty($endDate)) {
                 $endDate = Date::factory($endDate . ' 00:00:00');
             }
@@ -377,7 +410,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $startDate = Date::factory($startDate);
 
             $endDate = Common::getRequestVar('endDate', null, 'string');
-            $endDate = Date::factory($endDate);
+	        $endDate = $this->setFixedEndDateIfWordPress($endDate);
+
+	        $endDate = Date::factory($endDate);
 
             /** @var ImportStatus $importStatus */
             $importStatus = StaticContainer::get(ImportStatus::class);

--- a/Input/EndDate.php
+++ b/Input/EndDate.php
@@ -40,10 +40,8 @@ class EndDate
             if (empty($installDate)) {
                 // matomo for WordPress was installed before this option was set
                 // we have to make sure there will be an end date otherwise it will always overwrite data
-                // we use site creation date as an alternative
-                $site = new \WpMatomo\Site();
-                $idSite = $site->get_current_matomo_site_id();
-                $installDate = Date::factory(Site::getCreationDateFor($idSite))->subDay(1);
+                // we assume it was installed 2 days ago. It's not 100% accurate but best we can do
+                $installDate = Date::today()->subDay(2);
             } else {
                 // import up to 1 day before original install
                 $installDate = Date::factory($installDate)->subDay(1);

--- a/Input/EndDate.php
+++ b/Input/EndDate.php
@@ -15,58 +15,58 @@ use Piwik\Site;
 
 class EndDate
 {
-	/**
-	 * @internal tests only
-	 * @var null|string
-	 */
-	public $forceMaxEndDate = null;
+    /**
+     * @internal tests only
+     * @var null|string
+     */
+    public $forceMaxEndDate = null;
 
-	/**
-	 * @return Date|null
-	 */
-	public function getMaxEndDate()
-	{
-		// if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
-		// tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
-		// otherwise it would potentially always overwrite already aggregated report data
-		if (method_exists(SettingsServer::class, 'isMatomoForWordPress')
-		    && SettingsServer::isMatomoForWordPress()) {
+    /**
+     * @return Date|null
+     */
+    public function getMaxEndDate()
+    {
+        // if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
+        // tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
+        // otherwise it would potentially always overwrite already aggregated report data
+        if (method_exists(SettingsServer::class, 'isMatomoForWordPress')
+            && SettingsServer::isMatomoForWordPress()) {
 
-			$installDate = null;
-			if (defined('\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE')) {
-				$installDate = get_option(\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE);
-			}
+            $installDate = null;
+            if (defined('\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE')) {
+                $installDate = get_option(\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE);
+            }
 
-			if (empty($installDate)) {
-				// matomo for WordPress was installed before this option was set
-				// we have to make sure there will be an end date otherwise it will always overwrite data
-				// we use site creation date as an alternative
-				$site = new \WpMatomo\Site();
-				$idSite = $site->get_current_matomo_site_id();
-				$installDate = Date::factory(Site::getCreationDateFor($idSite))->subDay(1);
-			} else {
-				// import up to 1 day before original install
-				$installDate = Date::factory($installDate)->subDay(1);
-			}
+            if (empty($installDate)) {
+                // matomo for WordPress was installed before this option was set
+                // we have to make sure there will be an end date otherwise it will always overwrite data
+                // we use site creation date as an alternative
+                $site = new \WpMatomo\Site();
+                $idSite = $site->get_current_matomo_site_id();
+                $installDate = Date::factory(Site::getCreationDateFor($idSite))->subDay(1);
+            } else {
+                // import up to 1 day before original install
+                $installDate = Date::factory($installDate)->subDay(1);
+            }
 
-			return $installDate;
-		}
+            return $installDate;
+        }
 
-		if ($this->forceMaxEndDate) {
-			return Date::factory($this->forceMaxEndDate);
-		}
-	}
+        if ($this->forceMaxEndDate) {
+            return Date::factory($this->forceMaxEndDate);
+        }
+    }
 
-	public function limitMaxEndDateIfNeeded($endDate)
-	{
-		$maxEndDate = $this->getMaxEndDate();
-		// if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
-		// tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
-		// otherwise it would potentially always overwrite already aggregated report data
-		if ($maxEndDate && (!$endDate || Date::factory($endDate)->isLater($maxEndDate))) {
-			$endDate = $maxEndDate->toString();
-		}
+    public function limitMaxEndDateIfNeeded($endDate)
+    {
+        $maxEndDate = $this->getMaxEndDate();
+        // if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
+        // tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
+        // otherwise it would potentially always overwrite already aggregated report data
+        if ($maxEndDate && (!$endDate || Date::factory($endDate)->isLater($maxEndDate))) {
+            $endDate = $maxEndDate->toString();
+        }
 
-		return $endDate;
-	}
+        return $endDate;
+    }
 }

--- a/Input/EndDate.php
+++ b/Input/EndDate.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\Input;
+
+use Piwik\Date;
+use Piwik\SettingsServer;
+use Piwik\Site;
+
+class EndDate
+{
+	/**
+	 * @internal tests only
+	 * @var null|string
+	 */
+	public $forceMaxEndDate = null;
+
+	/**
+	 * @return Date|null
+	 */
+	public function getMaxEndDate()
+	{
+		// if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
+		// tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
+		// otherwise it would potentially always overwrite already aggregated report data
+		if (method_exists(SettingsServer::class, 'isMatomoForWordPress')
+		    && SettingsServer::isMatomoForWordPress()) {
+
+			$installDate = null;
+			if (defined('\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE')) {
+				$installDate = get_option(\WpMatomo\Installer::OPTION_NAME_INSTALL_DATE);
+			}
+
+			if (empty($installDate)) {
+				// matomo for WordPress was installed before this option was set
+				// we have to make sure there will be an end date otherwise it will always overwrite data
+				// we use site creation date as an alternative
+				$site = new \WpMatomo\Site();
+				$idSite = $site->get_current_matomo_site_id();
+				$installDate = Date::factory(Site::getCreationDateFor($idSite))->subDay(1);
+			} else {
+				// import up to 1 day before original install
+				$installDate = Date::factory($installDate)->subDay(1);
+			}
+
+			return $installDate;
+		}
+
+		if ($this->forceMaxEndDate) {
+			return Date::factory($this->forceMaxEndDate);
+		}
+	}
+
+	public function limitMaxEndDateIfNeeded($endDate)
+	{
+		$maxEndDate = $this->getMaxEndDate();
+		// if Matomo for WordPress is used, then the data will be imported into the same site as the data is also being
+		// tracked into by the sounds. So we need to make sure the import ends before Matomo for WordPress was installed
+		// otherwise it would potentially always overwrite already aggregated report data
+		if ($maxEndDate && (!$endDate || Date::factory($endDate)->isLater($maxEndDate))) {
+			$endDate = $maxEndDate->toString();
+		}
+
+		return $endDate;
+	}
+}

--- a/Input/MaxEndDateReached.php
+++ b/Input/MaxEndDateReached.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\Input;
+
+
+class MaxEndDateReached extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Max end date reached.');
+    }
+}

--- a/tests/Unit/Input/EndDateTest.php
+++ b/tests/Unit/Input/EndDateTest.php
@@ -18,43 +18,43 @@ class EndDateTest extends \PHPUnit_Framework_TestCase
 
     public function test_getMaxEndDate()
     {
-    	$maxEndDate = new EndDate();
-    	$this->assertNull($maxEndDate->getMaxEndDate());
+        $maxEndDate = new EndDate();
+        $this->assertNull($maxEndDate->getMaxEndDate());
     }
 
     public function test_getMaxEndDate_forcedDate()
     {
-    	$maxEndDate = new EndDate();
-    	$maxEndDate->forceMaxEndDate = '2020-03-19';
-    	$this->assertSame('2020-03-19', $maxEndDate->getMaxEndDate()->toString());
+        $maxEndDate = new EndDate();
+        $maxEndDate->forceMaxEndDate = '2020-03-19';
+        $this->assertSame('2020-03-19', $maxEndDate->getMaxEndDate()->toString());
     }
 
     public function test_limitMaxEndDateIfNeeded()
     {
-    	$maxEndDate = new EndDate();
-    	$this->assertSame('', $maxEndDate->limitMaxEndDateIfNeeded(''));
-    	$this->assertSame('2019-01-02', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+        $maxEndDate = new EndDate();
+        $this->assertSame('', $maxEndDate->limitMaxEndDateIfNeeded(''));
+        $this->assertSame('2019-01-02', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
     }
 
     public function test_limitMaxEndDateIfNeeded_noNeedToLimit()
     {
-    	$maxEndDate = new EndDate();
-	    $maxEndDate->forceMaxEndDate = '2020-03-19';
-    	$this->assertSame('2019-03-19', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+        $maxEndDate = new EndDate();
+        $maxEndDate->forceMaxEndDate = '2020-03-19';
+        $this->assertSame('2019-01-02', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
     }
 
     public function test_limitMaxEndDateIfNeeded_whenNoEndDateSetShouldLimit()
     {
-    	$maxEndDate = new EndDate();
-	    $maxEndDate->forceMaxEndDate = '2020-03-19';
-    	$this->assertSame('2019-03-19', $maxEndDate->limitMaxEndDateIfNeeded(''));
+        $maxEndDate = new EndDate();
+        $maxEndDate->forceMaxEndDate = '2020-03-19';
+        $this->assertSame('2020-03-19', $maxEndDate->limitMaxEndDateIfNeeded(''));
     }
 
     public function test_limitMaxEndDateIfNeeded_shouldLimitWhenMaxDateOlder()
     {
-    	$maxEndDate = new EndDate();
-	    $maxEndDate->forceMaxEndDate = '2018-03-19';
-    	$this->assertSame('2018-03-19', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+        $maxEndDate = new EndDate();
+        $maxEndDate->forceMaxEndDate = '2018-03-19';
+        $this->assertSame('2018-03-19', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
     }
 
 }

--- a/tests/Unit/Input/EndDateTest.php
+++ b/tests/Unit/Input/EndDateTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\tests\Unit\Google;
+
+use Piwik\Metrics;
+use Piwik\Plugins\GoogleAnalyticsImporter\Google\GoogleMetricMapper;
+use Piwik\Plugins\GoogleAnalyticsImporter\Input\EndDate;
+
+class EndDateTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function test_getMaxEndDate()
+    {
+    	$maxEndDate = new EndDate();
+    	$this->assertNull($maxEndDate->getMaxEndDate());
+    }
+
+    public function test_getMaxEndDate_forcedDate()
+    {
+    	$maxEndDate = new EndDate();
+    	$maxEndDate->forceMaxEndDate = '2020-03-19';
+    	$this->assertSame('2020-03-19', $maxEndDate->getMaxEndDate()->toString());
+    }
+
+    public function test_limitMaxEndDateIfNeeded()
+    {
+    	$maxEndDate = new EndDate();
+    	$this->assertSame('', $maxEndDate->limitMaxEndDateIfNeeded(''));
+    	$this->assertSame('2019-01-02', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+    }
+
+    public function test_limitMaxEndDateIfNeeded_noNeedToLimit()
+    {
+    	$maxEndDate = new EndDate();
+	    $maxEndDate->forceMaxEndDate = '2020-03-19';
+    	$this->assertSame('2019-03-19', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+    }
+
+    public function test_limitMaxEndDateIfNeeded_whenNoEndDateSetShouldLimit()
+    {
+    	$maxEndDate = new EndDate();
+	    $maxEndDate->forceMaxEndDate = '2020-03-19';
+    	$this->assertSame('2019-03-19', $maxEndDate->limitMaxEndDateIfNeeded(''));
+    }
+
+    public function test_limitMaxEndDateIfNeeded_shouldLimitWhenMaxDateOlder()
+    {
+    	$maxEndDate = new EndDate();
+	    $maxEndDate->forceMaxEndDate = '2018-03-19';
+    	$this->assertSame('2018-03-19', $maxEndDate->limitMaxEndDateIfNeeded('2019-01-02'));
+    }
+
+}


### PR DESCRIPTION
See https://wordpress.org/support/topic/google-analytics-importer/

@diosmosis do you think that would work? see the comments and the original support thread on what is happening.

I couldn't really test it but it seems to not create a new site in Matomo for WordPress but import data into existing site and the goal be to not have it overwrite any data from after the install date of Matomo for WordPress.

So:
* On 2020-07-07 Matomo for WordPress is installed.

Then I'm trying to force an end date of max 2020-07-06 basically if none is set, or if a later end date is set.