### PR TITLE
fix forum link in error message

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -200,7 +200,7 @@
                                 <br/>
                                 {{ 'GoogleAnalyticsImporter_ErrorMessage'|translate }}: {{ status.error|default('no message') }}
                                 <br/>
-                                {{ 'GoogleAnalyticsImporter_ErrorMessageBugReportRequest'|translate('<a href="http://forums.matomo.org/" rell="noreferrer noopener" target="_blank">', '</a>')|raw }}
+                                {{ 'GoogleAnalyticsImporter_ErrorMessageBugReportRequest'|translate('<a href="https://forum.matomo.org/" rell="noreferrer noopener" target="_blank">', '</a>')|raw }}
                             {% elseif status.status == 'killed' %}
                                 <span
                                         class="icon icon-help"


### PR DESCRIPTION
Moved the `s` to the right position

reported in https://forum.matomo.org/t/ga-importer-error-on-day-yyyy-mm-dd-failed-to-reach-ga-after-30-attempts/38194