### PR TITLE
trim property/view/account ID when starting an import to avoid errors on typos

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -323,9 +323,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             /** @var Importer $importer */
             $importer = StaticContainer::get(Importer::class);
 
-            $propertyId = Common::getRequestVar('propertyId');
-            $viewId = Common::getRequestVar('viewId');
-            $accountId = Common::getRequestVar('accountId', false);
+            $propertyId = trim(Common::getRequestVar('propertyId'));
+            $viewId = trim(Common::getRequestVar('viewId'));
+            $accountId = trim(Common::getRequestVar('accountId', false));
             $account = $accountId ?: ImportReports::guessAccountFromProperty($propertyId);
             $isMobileApp = Common::getRequestVar('isMobileApp', 0, 'int') == 1;
             $timezone = trim(Common::getRequestVar('timezone', '', 'string'));

--- a/tests/UI/GoogleAnalyticsImporter_spec.js
+++ b/tests/UI/GoogleAnalyticsImporter_spec.js
@@ -28,8 +28,8 @@ describe("GoogleAnalyticsImporter", function () {
     it("should start an import properly", async function () {
         await page.type('input#startDate', '2019-06-27');
         await page.type('input#endDate', '2019-07-02');
-        await page.type('input#propertyId', 'UA-12345-6');
-        await page.type('input#accountId', '12345');
+        await page.type('input#propertyId', 'UA-12345-6  '); // whitespace on purpose to test trim
+        await page.type('input#accountId', '  12345'); // whitespace on purpose to test trim
         await page.type('input#viewId', '1234567');
         await page.evaluate(() => $('div[name=extraCustomDimensions] input.control_text').val('ga:networkLocation').change());
         await page.evaluate(() => $('div[name=extraCustomDimensions] select:eq(0)').val('string:visit').change());


### PR DESCRIPTION
This can likely be an annoying/frustrating error to encounter, especially as the error is not very clear