### PR TITLE
Catch cancelled import exceptions and do not propagate in import reports command

### DIFF
--- a/Commands/ImportReports.php
+++ b/Commands/ImportReports.php
@@ -21,6 +21,7 @@ use Piwik\Plugins\GoogleAnalyticsImporter\ImportConfiguration;
 use Piwik\Plugins\GoogleAnalyticsImporter\Importer;
 use Piwik\Plugins\GoogleAnalyticsImporter\ImportLock;
 use Piwik\Plugins\GoogleAnalyticsImporter\ImportStatus;
+use Piwik\Plugins\GoogleAnalyticsImporter\ImportWasCancelledException;
 use Piwik\Plugins\GoogleAnalyticsImporter\Logger\LogToSingleFileProcessor;
 use Piwik\Plugins\GoogleAnalyticsImporter\Tasks;
 use Piwik\Plugins\WebsiteMeasurable\Type;
@@ -55,6 +56,15 @@ class ImportReports extends ConsoleCommand
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            return $this->executeImpl($input, $output);
+        } catch (ImportWasCancelledException $ex) {
+            $output->writeln("Import was cancelled, aborting.");
+        }
+    }
+
+    protected function executeImpl(InputInterface $input, OutputInterface $output)
     {
         $isAccountDeduced = false;
 

--- a/ImportStatus.php
+++ b/ImportStatus.php
@@ -173,7 +173,7 @@ class ImportStatus
         Option::clearCachedOption($optionName);
         $data = Option::get($optionName);
         if (empty($data)) {
-            throw new \Exception("Import was cancelled.");
+            throw new ImportWasCancelledException();
         }
         $data = json_decode($data, true);
         return $data;

--- a/ImportWasCancelledException.php
+++ b/ImportWasCancelledException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter;
+
+
+class ImportWasCancelledException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct("Import was cancelled.");
+    }
+}


### PR DESCRIPTION
This way they will not appear as fatal errors.