### PR TITLE
Started using polyfill for bcmath to work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/promises": "1.5.1",
         "google/analytics-data": "^0.8.1",
-        "google/analytics-admin": "^0.5.1"
+        "google/analytics-admin": "^0.5.1",
+        "phpseclib/bcmath_compat": "^2.0"
     },
     "replace": {
         "monolog/monolog": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe3294324bf17fe0bdd02523f3687bd7",
+    "content-hash": "f123bcdf6696f8c84d955466a22efc35",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -1021,6 +1021,68 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpseclib/bcmath_compat",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/bcmath_compat.git",
+                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/bcmath_compat/zipball/2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
+                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
+                "shasum": ""
+            },
+            "require": {
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "provide": {
+                "ext-bcmath": "8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "suggest": {
+                "ext-gmp": "Will enable faster math operations"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/bcmath.php"
+                ],
+                "psr-4": {
+                    "bcmath_compat\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "homepage": "http://phpseclib.sourceforge.net"
+                }
+            ],
+            "description": "PHP 5.x-8.x polyfill for bcmath extension",
+            "keywords": [
+                "BigInteger",
+                "bcmath",
+                "bigdecimal",
+                "math",
+                "polyfill"
+            ],
+            "support": {
+                "email": "terrafrost@php.net",
+                "issues": "https://github.com/phpseclib/bcmath_compat/issues",
+                "source": "https://github.com/phpseclib/bcmath_compat"
+            },
+            "time": "2021-12-16T02:35:52+00:00"
         },
         {
             "name": "phpseclib/phpseclib",

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -13,4 +13,5 @@ return array(
     'decc78cc4436b1292c6c0d151b19445c' => $vendorDir . '/phpseclib/phpseclib/phpseclib/bootstrap.php',
     '1f87db08236948d07391152dccb70f04' => $vendorDir . '/google/apiclient-services/autoload.php',
     'a8d3953fd9959404dd22d3dfcd0a79f0' => $vendorDir . '/google/apiclient/src/aliases.php',
+    '56823cacd97af379eceaf82ad00b928f' => $vendorDir . '/phpseclib/bcmath_compat/lib/bcmath.php',
 );

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -7,6 +7,7 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'phpseclib3\\' => array($vendorDir . '/phpseclib/phpseclib/phpseclib'),
+    'bcmath_compat\\' => array($vendorDir . '/phpseclib/bcmath_compat/src'),
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-factory/src', $vendorDir . '/psr/http-message/src'),
     'Psr\\Http\\Client\\' => array($vendorDir . '/psr/http-client/src'),
     'Psr\\Cache\\' => array($vendorDir . '/psr/cache/src'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -14,12 +14,17 @@ class ComposerStaticInitbfe0ce4af7932a343124a58229b00de0
         'decc78cc4436b1292c6c0d151b19445c' => __DIR__ . '/..' . '/phpseclib/phpseclib/phpseclib/bootstrap.php',
         '1f87db08236948d07391152dccb70f04' => __DIR__ . '/..' . '/google/apiclient-services/autoload.php',
         'a8d3953fd9959404dd22d3dfcd0a79f0' => __DIR__ . '/..' . '/google/apiclient/src/aliases.php',
+        '56823cacd97af379eceaf82ad00b928f' => __DIR__ . '/..' . '/phpseclib/bcmath_compat/lib/bcmath.php',
     );
 
     public static $prefixLengthsPsr4 = array (
         'p' => 
         array (
             'phpseclib3\\' => 11,
+        ),
+        'b' => 
+        array (
+            'bcmath_compat\\' => 14,
         ),
         'P' => 
         array (
@@ -58,6 +63,10 @@ class ComposerStaticInitbfe0ce4af7932a343124a58229b00de0
         'phpseclib3\\' => 
         array (
             0 => __DIR__ . '/..' . '/phpseclib/phpseclib/phpseclib',
+        ),
+        'bcmath_compat\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/phpseclib/bcmath_compat/src',
         ),
         'Psr\\Http\\Message\\' => 
         array (

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1065,6 +1065,71 @@
             "install-path": "../paragonie/random_compat"
         },
         {
+            "name": "phpseclib/bcmath_compat",
+            "version": "2.0.1",
+            "version_normalized": "2.0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/bcmath_compat.git",
+                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/bcmath_compat/zipball/2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
+                "reference": "2ffea8bfe1702b4535a7b3c2649c4301968e9a3c",
+                "shasum": ""
+            },
+            "require": {
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "provide": {
+                "ext-bcmath": "8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "suggest": {
+                "ext-gmp": "Will enable faster math operations"
+            },
+            "time": "2021-12-16T02:35:52+00:00",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "files": [
+                    "lib/bcmath.php"
+                ],
+                "psr-4": {
+                    "bcmath_compat\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "homepage": "http://phpseclib.sourceforge.net"
+                }
+            ],
+            "description": "PHP 5.x-8.x polyfill for bcmath extension",
+            "keywords": [
+                "BigInteger",
+                "bcmath",
+                "bigdecimal",
+                "math",
+                "polyfill"
+            ],
+            "support": {
+                "email": "terrafrost@php.net",
+                "issues": "https://github.com/phpseclib/bcmath_compat/issues",
+                "source": "https://github.com/phpseclib/bcmath_compat"
+            },
+            "install-path": "../phpseclib/bcmath_compat"
+        },
+        {
             "name": "phpseclib/phpseclib",
             "version": "3.0.14",
             "version_normalized": "3.0.14.0",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'ca30a399c0a5a7a8e7eb62820d8f5c15d0527d6f',
+        'reference' => 'fa633cc6bd4c5059507024bcf307a93628ea16b8',
         'name' => '__root__',
         'dev' => true,
     ),
@@ -16,7 +16,7 @@
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'ca30a399c0a5a7a8e7eb62820d8f5c15d0527d6f',
+            'reference' => 'fa633cc6bd4c5059507024bcf307a93628ea16b8',
             'dev_requirement' => false,
         ),
         'firebase/php-jwt' => array(
@@ -167,6 +167,15 @@
             'install_path' => __DIR__ . '/../paragonie/random_compat',
             'aliases' => array(),
             'reference' => '996434e5492cb4c3edcb9168db6fbb1359ef965a',
+            'dev_requirement' => false,
+        ),
+        'phpseclib/bcmath_compat' => array(
+            'pretty_version' => '2.0.1',
+            'version' => '2.0.1.0',
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../phpseclib/bcmath_compat',
+            'aliases' => array(),
+            'reference' => '2ffea8bfe1702b4535a7b3c2649c4301968e9a3c',
             'dev_requirement' => false,
         ),
         'phpseclib/phpseclib' => array(

--- a/vendor/phpseclib/bcmath_compat/lib/bcmath.php
+++ b/vendor/phpseclib/bcmath_compat/lib/bcmath.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * bcmath polyfill
+ *
+ * PHP versions 5 and 7
+ *
+ * LICENSE: Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2019 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @link      http://phpseclib.sourceforge.net
+ */
+
+use bcmath_compat\BCMath;
+
+if (!function_exists('bcadd')) {
+    /**
+     * Add two arbitrary precision numbers
+     *
+     * @var string $left_operand
+     * @var string $right_operand
+     * @var int $scale optional
+     */
+    function bcadd($left_operand, $right_operand, $scale = 0)
+    {
+        return BCMath::add($left_operand, $right_operand, $scale);
+    }
+
+    /**
+     * Compare two arbitrary precision numbers
+     *
+     * @var string $left_operand
+     * @var string $right_operand
+     * @var int $scale optional
+     */
+    function bccomp($left_operand, $right_operand, $scale = 0)
+    {
+        return BCMath::comp($left_operand, $right_operand, $scale);
+    }
+
+    /**
+     * Divide two arbitrary precision numbers
+     *
+     * @var string $dividend
+     * @var string $divisor
+     * @var int $scale optional
+     */
+    function bcdiv($dividend, $divisor, $scale = 0)
+    {
+        return BCMath::div($dividend, $divisor, $scale);
+    }
+
+    /**
+     * Get modulus of an arbitrary precision number
+     *
+     * @var string $dividend
+     * @var string $divisor
+     * @var int $scale optional
+     */
+    function bcmod($dividend, $divisor, $scale = 0)
+    {
+        return BCMath::mod($dividend, $divisor, $scale);
+    }
+
+    /**
+     * Multiply two arbitrary precision numbers
+     *
+     * @var string $left_operand
+     * @var string $right_operand
+     * @var int $scale optional
+     */
+    function bcmul($dividend, $divisor, $scale = 0)
+    {
+        return BCMath::mul($dividend, $divisor, $scale);
+    }
+
+    /**
+     * Raise an arbitrary precision number to another
+     *
+     * @var string $base
+     * @var string $exponent
+     * @var int $scale optional
+     */
+    function bcpow($base, $exponent, $scale = 0)
+    {
+        return BCMath::pow($base, $exponent, $scale);
+    }
+
+    /**
+     * Raise an arbitrary precision number to another, reduced by a specified modulus
+     *
+     * @var string $base
+     * @var string $exponent
+     * @var string $modulus
+     * @var int $scale optional
+     */
+    function bcpowmod($base, $exponent, $modulus, $scale = 0)
+    {
+        return BCMath::powmod($base, $exponent, $modulus, $scale);
+    }
+
+    /**
+     * Set or get default scale parameter for all bc math functions
+     *
+     * @var int $scale
+     */
+    function bcscale($scale = null)
+    {
+        return BCMath::scale($scale);
+    }
+
+    /**
+     * Get the square root of an arbitrary precision number
+     *
+     * @var string $operand
+     * @var int $scale optional
+     */
+    function bcsqrt($operand, $scale = 0)
+    {
+        return BCMath::sqrt($operand, $scale);
+    }
+
+    /**
+     * Subtract one arbitrary precision number from another
+     *
+     * @var string $left_operand
+     * @var string $right_operand
+     * @var int $scale optional
+     */
+    function bcsub($left_operand, $right_operand, $scale = 0)
+    {
+        return BCMath::sub($left_operand, $right_operand, $scale);
+    }
+}
+
+// the following were introduced in PHP 7.0.0
+if (!class_exists('Error')) {
+    class Error extends Exception
+    {
+    }
+
+    class ArithmeticError extends Error
+    {
+    }
+
+    class DivisionByZeroError extends ArithmeticError
+    {
+    }
+
+    class TypeError extends Error
+    {
+    }
+}
+
+// the following was introduced in PHP 7.1.0
+if (!class_exists('ArgumentCountError')) {
+    class ArgumentCountError extends TypeError
+    {
+    }
+}
+
+// the following was introduced in PHP 8.0.0
+if (!class_exists('ValueError')) {
+    class ValueError extends Error
+    {
+    }
+}

--- a/vendor/phpseclib/bcmath_compat/src/BCMath.php
+++ b/vendor/phpseclib/bcmath_compat/src/BCMath.php
@@ -1,0 +1,494 @@
+<?php
+
+/**
+ * BCMath Emulation Class
+ *
+ * PHP version 5 and 7
+ *
+ * @author    Jim Wigginton <terrafrost@php.net>
+ * @copyright 2019 Jim Wigginton
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+namespace bcmath_compat;
+
+use phpseclib3\Math\BigInteger;
+
+/**
+ * BCMath Emulation Class
+ *
+ * @author  Jim Wigginton <terrafrost@php.net>
+ * @access  public
+ */
+abstract class BCMath
+{
+    /**
+     * Default scale parameter for all bc math functions
+     */
+    private static $scale;
+
+    /**
+     * Set or get default scale parameter for all bc math functions
+     *
+     * Uses the PHP 7.3+ behavior
+     *
+     * @var int $scale optional
+     */
+    private static function scale($scale = null)
+    {
+        if (isset($scale)) {
+            self::$scale = (int) $scale;
+        }
+        return self::$scale;
+    }
+
+    /**
+     * Formats numbers
+     *
+     * Places the decimal place at the appropriate place, adds trailing 0's as appropriate, etc
+     *
+     * @var string $x
+     * @var int $scale
+     * @var int $pad
+     * @var boolean $trim
+     */
+    private static function format($x, $scale, $pad)
+    {
+        $sign = self::isNegative($x) ? '-' : '';
+        $x = str_replace('-', '', $x);
+
+        if (strlen($x) != $pad) {
+            $x = str_pad($x, $pad, '0', STR_PAD_LEFT);
+        }
+        $temp = $pad ? substr_replace($x, '.', -$pad, 0) : $x;
+        $temp = explode('.', $temp);
+        if ($temp[0] == '') {
+            $temp[0] = '0';
+        }
+        if (isset($temp[1])) {
+            $temp[1] = substr($temp[1], 0, $scale);
+            $temp[1] = str_pad($temp[1], $scale, '0');
+        } elseif ($scale) {
+            $temp[1] = str_repeat('0', $scale);
+        }
+        $result = rtrim(implode('.', $temp), '.');
+        if ($sign == '-' && preg_match('#^0\.?0*$#', $result)) {
+            $sign = '';
+        }
+        return $sign . $result;
+    }
+
+    /**
+     * Negativity Test
+     *
+     * @var BigInteger $x
+     */
+    private static function isNegative($x)
+    {
+        return $x->compare(new BigInteger()) < 0;
+    }
+
+    /**
+     * Add two arbitrary precision numbers
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function add($x, $y, $scale, $pad)
+    {
+        $z = $x->add($y);
+
+        return self::format($z, $scale, $pad);
+    }
+
+    /**
+     * Subtract one arbitrary precision number from another
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function sub($x, $y, $scale, $pad)
+    {
+        $z = $x->subtract($y);
+
+        return self::format($z, $scale, $pad);
+    }
+
+    /**
+     * Multiply two arbitrary precision numbers
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function mul($x, $y, $scale, $pad)
+    {
+        if ($x == '0' || $y == '0') {
+            $r = '0';
+            if ($scale) {
+                $r.= '.' . str_repeat('0', $scale);
+            }
+            return $r;
+        }
+
+        $z = $x->abs()->multiply($y->abs());
+        $result = self::format($z, $scale, 2 * $pad);
+
+        $sign = (self::isNegative($x) ^ self::isNegative($y)) && !preg_match('#^0\.?0*$#', $result) ? '-' : '';
+
+        return $sign . $result;
+    }
+
+    /**
+     * Divide two arbitrary precision numbers
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function div($x, $y, $scale, $pad)
+    {
+        if ($y == '0') {
+            // < PHP 8.0 triggered a warning
+            // >= PHP 8.0 throws an exception
+            throw new \DivisionByZeroError('Division by zero');
+        }
+
+        $temp = '1' . str_repeat('0', $scale);
+        $temp = new BigInteger($temp);
+        list($q) = $x->multiply($temp)->divide($y);
+
+        return self::format($q, $scale, $scale);
+    }
+
+    /**
+     * Get modulus of an arbitrary precision number
+     *
+     * Uses the PHP 7.2+ behavior
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function mod($x, $y, $scale, $pad)
+    {
+        if ($y == '0') {
+            // < PHP 8.0 triggered a warning
+            // >= PHP 8.0 throws an exception
+            throw new \DivisionByZeroError('Division by zero');
+        }
+
+        list($q) = $x->divide($y);
+        $z = $y->multiply($q);
+        $z = $x->subtract($z);
+
+        return self::format($z, $scale, $pad);
+    }
+
+    /**
+     * Compare two arbitrary precision numbers
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function comp($x, $y, $scale, $pad)
+    {
+        $x = new BigInteger($x[0] . substr($x[1], 0, $scale));
+        $y = new BigInteger($y[0] . substr($y[1], 0, $scale));
+
+        return $x->compare($y);
+    }
+
+    /**
+     * Raise an arbitrary precision number to another
+     *
+     * Uses the PHP 7.2+ behavior
+     *
+     * @var string $x
+     * @var string $y
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function pow($x, $y, $scale, $pad)
+    {
+        if ($y == '0') {
+            $r = '1';
+            if ($scale) {
+                $r.= '.' . str_repeat('0', $scale);
+            }
+            return $r;
+        }
+
+        $min = defined('PHP_INT_MIN') ? PHP_INT_MIN : ~PHP_INT_MAX;
+        if (bccomp($y, PHP_INT_MAX) > 0 || bccomp($y, $min) <= 0) {
+            throw new \ValueError('bcpow(): Argument #2 ($exponent) is too large');
+        }
+
+        $sign = self::isNegative($x) ? '-' : '';
+        $x = $x->abs();
+
+        $r = new BigInteger(1);
+
+        for ($i = 0; $i < abs($y); $i++) {
+            $r = $r->multiply($x);
+        }
+
+        if ($y < 0) {
+            $temp = '1' . str_repeat('0', $scale + $pad * abs($y));
+            $temp = new BigInteger($temp);
+            list($r) = $temp->divide($r);
+            $pad = $scale;
+        } else {
+            $pad*= abs($y);
+        }
+
+        return $sign . self::format($r, $scale, $pad);
+    }
+
+    /**
+     * Raise an arbitrary precision number to another, reduced by a specified modulus
+     *
+     * @var string $x
+     * @var string $e
+     * @var string $n
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function powmod($x, $e, $n, $scale, $pad)
+    {
+        if ($e[0] == '-' || $n == '0') {
+            // < PHP 8.0 returned false
+            // >= PHP 8.0 throws an exception
+            throw new \ValueError('bcpowmod(): Argument #2 ($exponent) must be greater than or equal to 0');
+        }
+        if ($n[0] == '-') {
+            $n = substr($n, 1);
+        }
+        if ($e == '0') {
+            return $scale ?
+                '1.' . str_repeat('0', $scale) :
+                '1';
+        }
+
+        $x = new BigInteger($x);
+        $e = new BigInteger($e);
+        $n = new BigInteger($n);
+
+        $z = $x->powMod($e, $n);
+
+        return $scale ?
+            "$z." . str_repeat('0', $scale) :
+            "$z";
+    }
+
+    /**
+     * Get the square root of an arbitrary precision number
+     *
+     * @var string $n
+     * @var int $scale
+     * @var int $pad
+     */
+    private static function sqrt($n, $scale, $pad)
+    {
+        // the following is based off of the following URL:
+        // https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Decimal_(base_10)
+
+        if (!is_numeric($n)) {
+            return '0';
+        }
+        $temp = explode('.', $n);
+        $decStart = ceil(strlen($temp[0]) / 2);
+        $n = implode('', $temp);
+        if (strlen($n) % 2) {
+            $n = "0$n";
+        }
+        $parts = str_split($n, 2);
+        $parts = array_map('intval', $parts);
+        $i = 0;
+        $p = 0; // for the first step, p = 0
+        $c = $parts[$i];
+        $result = '';
+        while (true) {
+            // determine the greatest digit x such that x(20p+x) <= c
+            for ($x = 1; $x <= 10; $x++) {
+                if ($x * (20 * $p + $x) > $c) {
+                    $x--;
+                    break;
+                }
+            }
+            $result.= $x;
+            $y = $x * (20 * $p + $x);
+            $p = 10 * $p + $x;
+            $c = 100 * ($c - $y);
+            if (isset($parts[++$i])) {
+                $c+= $parts[$i];
+            }
+            if ((!$c && $i >= $decStart)  || $i - $decStart == $scale) {
+                break;
+            }
+            if ($decStart == $i) {
+                $result.= '.';
+            }
+        }
+
+        $result = explode('.', $result);
+        if (isset($result[1])) {
+            $result[1] = str_pad($result[1], $scale, '0');
+        } elseif ($scale) {
+            $result[1] = str_repeat('0', $scale);
+        }
+        return implode('.', $result);
+    }
+
+    /**
+     * __callStatic Magic Method
+     *
+     * @var string $name
+     * @var array $arguments
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        static $params = [
+            'add' => 3,
+            'comp' => 3,
+            'div' => 3,
+            'mod' => 3,
+            'mul' => 3,
+            'pow' => 3,
+            'powmod' => 4,
+            'scale' => 1,
+            'sqrt' => 2,
+            'sub' => 3
+        ];
+        if (count($arguments) < $params[$name] - 1) {
+            $min = $params[$name] - 1;
+            throw new \ArgumentCountError("bc$name() expects at least $min parameters, " . func_num_args() . " given");
+        }
+        if (count($arguments) > $params[$name]) {
+            $str = "bc$name() expects at most {$params[$name]} parameters, " . func_num_args() . " given";
+            throw new \ArgumentCountError($str);
+        }
+        $numbers = array_slice($arguments, 0, $params[$name] - 1);
+
+        $ints = [];
+        switch ($name) {
+            case 'pow':
+                $ints = array_slice($numbers, count($numbers) - 1);
+                $numbers = array_slice($numbers, 0, count($numbers) - 1);
+                $names = ['exponent'];
+                break;
+            case 'powmod':
+                $ints = $numbers;
+                $numbers = [];
+                $names = ['base', 'exponent', 'modulus'];
+                break;
+            case 'sqrt':
+                $names = ['num'];
+                break;
+            default:
+                $names = ['num1', 'num2'];
+        }
+        foreach ($ints as $i => &$int) {
+            if (!is_numeric($int)) {
+                $int = '0';
+            }
+            $pos = strpos($int, '.');
+            if ($pos !== false) {
+                $int = substr($int, 0, $pos);
+                throw new \ValueError("bc$name(): Argument #2 (\$$names[$i]) cannot have a fractional part");
+            }
+        }
+        foreach ($numbers as $i => $arg) {
+            $num = $i + 1;
+            switch (true) {
+                case is_bool($arg):
+                case is_numeric($arg):
+                case is_string($arg):
+                case is_object($arg) && method_exists($arg, '__toString'):
+                    if (!is_bool($arg) && !is_numeric("$arg")) {
+                        throw new \ValueError("bc$name: bcmath function argument is not well-formed");
+                    }
+                    break;
+                // PHP >= 8.1 has deprecated the passing of nulls to string parameters
+                case is_null($arg):
+                    $error = "bc$name(): Passing null to parameter #$num (\$$names[$i]) of type string is deprecated";
+                    trigger_error($error, E_USER_DEPRECATED);
+                    break;
+                default:
+                    $type = is_object($arg) ? get_class($arg) : gettype($arg);
+                    $error = "bc$name(): Argument #$num (\$$names[$i]) must be of type string, $type given";
+                    throw new \TypeError($error);
+            }
+        }
+        if (!isset(self::$scale)) {
+            $scale = ini_get('bcmath.scale');
+            self::$scale = $scale !== false ? max(intval($scale), 0) : 0;
+        }
+        $scale = isset($arguments[$params[$name] - 1]) ? $arguments[$params[$name] - 1] : self::$scale;
+        switch (true) {
+            case is_bool($scale):
+            case is_numeric($scale):
+            case is_string($scale) && preg_match('#0-9\.#', $scale[0]):
+                break;
+            default:
+                $type = is_object($arg) ? get_class($arg) : gettype($arg);
+                $str = "bc$name(): Argument #$params[$name] (\$scale) must be of type ?int, string given";
+                throw new \TypeError($str);
+        }
+        $scale = (int) $scale;
+        if ($scale < 0) {
+            throw new \ValueError("bc$name(): Argument #$params[$name] (\$scale) must be between 0 and 2147483647");
+        }
+
+        $pad = 0;
+        foreach ($numbers as &$num) {
+            if (is_bool($num)) {
+                $num = $num ? '1' : '0';
+            } elseif (!is_numeric($num)) {
+                $num = '0';
+            }
+            $num = explode('.', $num);
+            if (isset($num[1])) {
+                $pad = max($pad, strlen($num[1]));
+            }
+        }
+        switch ($name) {
+            case 'add':
+            case 'sub':
+            case 'mul':
+            case 'div':
+            case 'mod':
+            case 'pow':
+                foreach ($numbers as &$num) {
+                    if (!isset($num[1])) {
+                        $num[1] = '';
+                    }
+                    $num[1] = str_pad($num[1], $pad, '0');
+                    $num = new BigInteger($num[0] . $num[1]);
+                }
+                break;
+            case 'comp':
+                foreach ($numbers as &$num) {
+                    if (!isset($num[1])) {
+                        $num[1] = '';
+                    }
+                    $num[1] = str_pad($num[1], $pad, '0');
+                }
+                break;
+            case 'sqrt':
+                $numbers = [$arguments[0]];
+        }
+
+        $arguments = array_merge($numbers, $ints, [$scale, $pad]);
+        return call_user_func_array('self::' . $name, $arguments);
+    }
+}


### PR DESCRIPTION
### Description:

Started using polyfill for bcmath to work.
We recently faced a issue on our cloud that `php-bcmath` was not installed and it was throwing exception, to resolve this error we decided to use a polyfill since many of the customers will just upgrade the plugin and might not install new php extension, so in that case this polyfill can be used.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
