### PR TITLE
Updating error message when a use cancels auth to be more helpful

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -36,6 +36,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         $errorMessage = $errorMessage ?: Common::getRequestVar('error', '');
         if (!empty($errorMessage)) {
+            if ($errorMessage === 'access_denied') {
+                $errorMessage = Piwik::translate('GoogleAnalyticsImporter_OauthFailedMessage');
+            }
             $notification = new Notification($errorMessage);
             $notification->context = Notification::CONTEXT_ERROR;
             $notification->type = Notification::TYPE_TRANSIENT;

--- a/GoogleAnalyticsImporter.php
+++ b/GoogleAnalyticsImporter.php
@@ -220,6 +220,7 @@ class GoogleAnalyticsImporter extends \Piwik\Plugin
         $translationKeys[] = 'GoogleAnalyticsImporter_PendingGAImportReportNotificationSomeData';
         $translationKeys[] = 'GoogleAnalyticsImporter_NoDateSuccessImportMessageLine1';
         $translationKeys[] = 'GoogleAnalyticsImporter_NoDateSuccessImportMessageLine2';
+        $translationKeys[] = 'GoogleAnalyticsImporter_OauthFailedMessage';
     }
 
     public function getJsFiles(&$files)

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,7 +16,7 @@
         "ConfigureClientDesc2": "%1$sTo start follow our instructions to retrieve your OAuth Client configuration.%2$s Then either upload this client configuration or paste it into the field below.",
         "ConfigurationFile": "Configuration File",
         "ConfigurationText": "Configuration Text",
-        "InvalidRedirectUriInClientConfiguration": "Invalid redirect_uris, atleast 1 uri should match the uri \"%1$s\" in the uploaded configuration file",
+        "InvalidRedirectUriInClientConfiguration": "Invalid redirect_uris, at least 1 uri should match the uri \"%1$s\" in the uploaded configuration file",
         "RemoveClientConfiguration": "Remove Client Configuration",
         "DeleteUploadedClientConfig": "If you'd like to remove the uploaded client configuration, click below",
         "ImportJobs": "Import Jobs",
@@ -121,6 +121,7 @@
         "PendingGAImportReportNotificationNoData" : "We are still importing from Google Analytics but you should be able to see your most recent data. You will be able to view all your data within a few days.",
         "PendingGAImportReportNotificationSomeData" : "We are still importing from Google Analytics but you should be able to see your most recent data. Data until %1$s has been imported so far. You should be able to see your importer data since this date.",
         "NoDateSuccessImportMessageLine1": "Your Google Analytics properties were imported successfully",
-        "NoDateSuccessImportMessageLine2": "Historical reports for these properties will be imported in the background. Please be patient as this will take a few days to complete. It's now time to set up the tracking of new data (see instructions below)."
+        "NoDateSuccessImportMessageLine2": "Historical reports for these properties will be imported in the background. Please be patient as this will take a few days to complete. It's now time to set up the tracking of new data (see instructions below).",
+        "OauthFailedMessage": "We encountered an issue during the authorization process for importing your GA reports. To try again, please click the button below. If the problem persists, please contact our support team for assistance. They will assist you in resolving the issue and getting your historical GA data imported."
     }
 }


### PR DESCRIPTION
### Description:

Currently,  when a user cancels during the authorisation process they are redirected with the error message `access_denied`. It was decided that we should have a more user friendly message. This is to match the change we're making in the ConnectAccounts plugin for Jira issue PG-1537.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
