### PR TITLE
Call addSite API through processRequest method to ensure events are triggered

### DIFF
--- a/Importer.php
+++ b/Importer.php
@@ -174,7 +174,7 @@ class Importer
                     'siteName' => $webproperty->getName(),
                     'urls' => $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webproperty->getWebsiteUrl()],
                     'ecommerce' => $view->eCommerceTracking ? 1 : 0,
-                    'siteSearch' => !empty($view->siteSearchQueryParameters),
+                    'siteSearch' => (int) !empty($view->siteSearchQueryParameters),
                     'searchKeywordParameters' => $view->siteSearchQueryParameters,
                     'searchCategoryParameters' => $view->siteSearchCategoryParameters,
                     'excludedQueryParameters' => $view->excludeQueryParameters,

--- a/Importer.php
+++ b/Importer.php
@@ -170,22 +170,18 @@ class Importer
 
             $startDate = Date::factory($webproperty->getCreated())->toString();
             if (!method_exists(SettingsServer::class, 'isMatomoForWordPress') || !SettingsServer::isMatomoForWordPress()) {
-                $idSite = SitesManagerAPI::getInstance()->addSite(
-                    $siteName = $webproperty->getName(),
-                    $urls = $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webproperty->getWebsiteUrl()],
-                    $ecommerce = $view->eCommerceTracking ? 1 : 0,
-                    $siteSearch = !empty($view->siteSearchQueryParameters),
-                    $searchKeywordParams = $view->siteSearchQueryParameters,
-                    $searchCategoryParams = $view->siteSearchCategoryParameters,
-                    $excludedIps = null,
-                    $excludedParams = $view->excludeQueryParameters,
-                    $timezone = empty($timezone) ? $view->timezone : $timezone,
-                    $currency = $view->currency,
-                    $group = null,
-                    $startDate,
-                    $excludedUserAgents = null,
-                    $keepURLFragments = null,
-                    $type
+                $idSite = Request::processRequest('SitesManager.addSite', [
+                    'siteName' => $webproperty->getName(),
+                    'urls' => $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webproperty->getWebsiteUrl()],
+                    'ecommerce' => $view->eCommerceTracking ? 1 : 0,
+                    'siteSearch' => !empty($view->siteSearchQueryParameters),
+                    'searchKeywordParameters' => $view->siteSearchQueryParameters,
+                    'searchCategoryParameters' => $view->siteSearchCategoryParameters,
+                    'excludedQueryParameters' => $view->excludeQueryParameters,
+                    'timezone' => empty($timezone) ? $view->timezone : $timezone,
+                    'currency' => $view->currency,
+                    'startDate' => $startDate,
+                    'type' => $type]
                 );
             } else { // matomo for wordpress
                 $site = new \WpMatomo\Site();

--- a/ImporterGA4.php
+++ b/ImporterGA4.php
@@ -189,7 +189,7 @@ class ImporterGA4
                         'siteName' => $webProperty->getDisplayName(),
                         'urls' => $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webProperty->getDisplayName()],
                         'ecommerce' => 1,
-                        'siteSearch' => false,
+                        'siteSearch' => 0,
                         'searchKeywordParameters' => '',
                         'searchCategoryParameters' => '',
                         'excludedQueryParameters' => '',

--- a/ImporterGA4.php
+++ b/ImporterGA4.php
@@ -185,22 +185,18 @@ class ImporterGA4
 
             $startDate = Date::factory($webProperty->getCreateTime()->toDateTime()->getTimestamp())->toString();
             if (!method_exists(SettingsServer::class, 'isMatomoForWordPress') || !SettingsServer::isMatomoForWordPress()) {
-                $idSite = SitesManagerAPI::getInstance()->addSite(
-                    $siteName = $webProperty->getDisplayName(),
-                    $urls = $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webProperty->getDisplayName()],
-                    $ecommerce = 1,
-                    $siteSearch = false,
-                    $searchKeywordParams = '',
-                    $searchCategoryParams = '',
-                    $excludedIps = null,
-                    $excludedParams = '',
-                    $timezone = empty($timezone) ? $webProperty->getTimeZone() : $timezone,
-                    $currency = $webProperty->getCurrencyCode(),
-                    $group = null,
-                    $startDate,
-                    $excludedUserAgents = null,
-                    $keepURLFragments = null,
-                    $type
+                $idSite = Request::processRequest('SitesManager.addSite', [
+                        'siteName' => $webProperty->getDisplayName(),
+                        'urls' => $type === \Piwik\Plugins\MobileAppMeasurable\Type::ID ? null : [$webProperty->getDisplayName()],
+                        'ecommerce' => 1,
+                        'siteSearch' => false,
+                        'searchKeywordParameters' => '',
+                        'searchCategoryParameters' => '',
+                        'excludedQueryParameters' => '',
+                        'timezone' => empty($timezone) ? $webProperty->getTimeZone() : $timezone,
+                        'currency' => $webProperty->getCurrencyCode(),
+                        'startDate' => $startDate,
+                        'type' => $type]
                 );
             } else { // matomo for wordpress
                 $site = new \WpMatomo\Site();


### PR DESCRIPTION
### Description:

The problem is that the plugin calls addSite directly instead of using Request::processRequest  which it should according to our [best practices](https://developer.matomo.org/guides/expose-api-methods#calling-other-plugins-apis).

By using `processRequest` we ensure that all related events will be triggered and other plugins will be informed about the creation of a new site like the events `API.SitesManager.addSite` and `API.SitesManager.addSite.end`. 

This allows the Cloud to then enforce for example quotas which isn't possible when `addSite` is called directly.

Note: I didn't actually test it as I haven't set this up previously.

This is to fix CLOUD-1211

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
