### PR TITLE
Add some more brand mappings

### DIFF
--- a/Importers/DevicesDetection/RecordImporter.php
+++ b/Importers/DevicesDetection/RecordImporter.php
@@ -280,11 +280,18 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
         $result = $this->cache->fetch($cacheKey);
         if (empty($result)) {
             $result = $this->buildValueMapping(DeviceParser::$deviceBrands);
-            $result['oukitel'] = $result['ouki'];
+            $result['honor'] = $result['huawei'];
+            $result['caterpillar'] = $result['cat'];
+            $result['tp-link'] = $result['neffos'];
+            $result['nothing'] = $result['nothing phone'];
+            $result['coby'] = $result['coby kyros'];
+            $result['kruger&matz'] = $result['krüger&matz'];
             $result['blackberry'] = $result['rim'];
             $result['tecno'] = $result['tecno mobile'];
             $result['sonyericsson'] = $result['sony ericsson'];
-            $result['opera'] = 'xx';
+            $result['mozilla'] = 'xx'; // browser, not a brand
+            $result['feiteng'] = 'xx'; // Feiteng is a processor type, to a brand
+            $result['opera'] = 'xx'; // browser, not a brand
             $result['mobiwire'] = 'xx';
             $result['creative'] = 'xx';
             $this->cache->save($cacheKey, $result);

--- a/tests/System/expected/test___DevicesDetection.getBrand_month.xml
+++ b/tests/System/expected/test___DevicesDetection.getBrand_month.xml
@@ -406,7 +406,7 @@
 		<segment>deviceBrand==Motorola</segment>
 	</row>
 	<row>
-		<label>Ouki</label>
+		<label>Oukitel</label>
 		<nb_visits>1</nb_visits>
 		<nb_actions>1</nb_actions>
 		<sum_visit_length>0</sum_visit_length>
@@ -447,8 +447,8 @@
 			</row>
 		</goals>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<logo>plugins/Morpheus/icons/dist/brand/unk.png</logo>
-		<segment>deviceBrand==Ouki</segment>
+		<logo>plugins/Morpheus/icons/dist/brand/Oukitel.png</logo>
+		<segment>deviceBrand==Oukitel</segment>
 	</row>
 	<row>
 		<label>Xiaomi</label>

--- a/tests/System/expected/test___DevicesDetection.getBrand_week.xml
+++ b/tests/System/expected/test___DevicesDetection.getBrand_week.xml
@@ -406,7 +406,7 @@
 		<segment>deviceBrand==Motorola</segment>
 	</row>
 	<row>
-		<label>Ouki</label>
+		<label>Oukitel</label>
 		<nb_visits>1</nb_visits>
 		<nb_actions>1</nb_actions>
 		<sum_visit_length>0</sum_visit_length>
@@ -447,8 +447,8 @@
 			</row>
 		</goals>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<logo>plugins/Morpheus/icons/dist/brand/unk.png</logo>
-		<segment>deviceBrand==Ouki</segment>
+		<logo>plugins/Morpheus/icons/dist/brand/Oukitel.png</logo>
+		<segment>deviceBrand==Oukitel</segment>
 	</row>
 	<row>
 		<label>Xiaomi</label>

--- a/tests/System/expected/test___DevicesDetection.getBrand_year.xml
+++ b/tests/System/expected/test___DevicesDetection.getBrand_year.xml
@@ -406,7 +406,7 @@
 		<segment>deviceBrand==Motorola</segment>
 	</row>
 	<row>
-		<label>Ouki</label>
+		<label>Oukitel</label>
 		<nb_visits>1</nb_visits>
 		<nb_actions>1</nb_actions>
 		<sum_visit_length>0</sum_visit_length>
@@ -447,8 +447,8 @@
 			</row>
 		</goals>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<logo>plugins/Morpheus/icons/dist/brand/unk.png</logo>
-		<segment>deviceBrand==Ouki</segment>
+		<logo>plugins/Morpheus/icons/dist/brand/Oukitel.png</logo>
+		<segment>deviceBrand==Oukitel</segment>
 	</row>
 	<row>
 		<label>Unknown</label>


### PR DESCRIPTION
### Description:

While importing, the plugin tries to match the brands reported by the Google API to those known by device detector.
As cloud is running a lot imports we discovered some brands that are often reported by google, but can't be mapped to ours.
This additional mappings should cover some very common ones.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
