### PR TITLE
Added the ability to show a security error

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -55,6 +55,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         if (!empty($errorMessage)) {
             if ($errorMessage === 'access_denied') {
                 $errorMessage = Piwik::translate('GoogleAnalyticsImporter_OauthFailedMessage');
+            } elseif ($errorMessage === 'jwt_validation_error') {
+                $errorMessage = Piwik::translate('General_ExceptionSecurityCheckFailed');
             }
             $notification = new Notification($errorMessage);
             $notification->context = Notification::CONTEXT_ERROR;


### PR DESCRIPTION
### Description:

Adding the handling for a specific security error. This is related to changes in some of our premium plugins.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
