### PR TITLE
Fix YaBrowser mapping

### DIFF
--- a/Importers/DevicesDetection/RecordImporter.php
+++ b/Importers/DevicesDetection/RecordImporter.php
@@ -344,6 +344,7 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
             $result['nintendo browser'] = $result['netfront'];
             $result['nintendo wiiu'] = $result['netfront'];
             $result['nintendo wii'] = $result['netfront'];
+            $result['yabrowser'] = $result['yandex browser'];
             $result['terra'] = 'xx'; // TODO: not detected by devices detection
             $result['mozilla compatible agent'] = 'xx'; // TODO: mostly bots, we could ignore these...
             $result['\'mozilla'] = 'xx';

--- a/Importers/DevicesDetection/RecordImporterGA4.php
+++ b/Importers/DevicesDetection/RecordImporterGA4.php
@@ -339,6 +339,7 @@ class RecordImporterGA4 extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImp
             $result['nintendo browser'] = $result['netfront'];
             $result['nintendo wiiu'] = $result['netfront'];
             $result['nintendo wii'] = $result['netfront'];
+            $result['yabrowser'] = $result['yandex browser'];
             $result['terra'] = 'xx'; // TODO: not detected by devices detection
             $result['mozilla compatible agent'] = 'xx'; // TODO: mostly bots, we could ignore these...
             $result['\'mozilla'] = 'xx';


### PR DESCRIPTION
### Description:

Matomo seems to already support the Yandex Browser under this name. However, in GA, it's known as YaBrowser. This fixes the mapping error `Encountered unknown browser: YaBrowser`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
