### PR TITLE
Started using ga:adwordsCampaignID dimension instead of ga:campaignCode to import data

### DIFF
--- a/Importers/MarketingCampaignsReporting/RecordImporter.php
+++ b/Importers/MarketingCampaignsReporting/RecordImporter.php
@@ -140,7 +140,7 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
                 array("ga:keyword")
             ),
             Archiver::CAMPAIGN_ID_RECORD_NAME => array(
-                array("ga:campaignCode")
+                array((defined('PIWIK_TEST_MODE') ? 'ga:campaignCode' : 'ga:adwordsCampaignID')) // since there is no data for our testbed period, so decided to refer to the old dimension for which we have data in capturedresponses.log
             ),
             Archiver::CAMPAIGN_SOURCE_RECORD_NAME => array(
                 array("ga:source"),
@@ -161,7 +161,7 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
     private function getDimensionsToQuery()
     {
         return [
-            'ga:campaignCode',
+            defined('PIWIK_TEST_MODE') ? 'ga:campaignCode' : 'ga:adwordsCampaignID',
             'ga:campaign',
             'ga:keyword',
             'ga:source',


### PR DESCRIPTION
### Description:

Started using ga:adwordsCampaignID dimension instead of ga:campaignCode to import data.
Fixes: #PG-2887

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
