### PR TITLE
Fix issue where error is thrown if idSite isn't set after oauth error

### DIFF
--- a/GoogleAnalyticsImporter.php
+++ b/GoogleAnalyticsImporter.php
@@ -24,6 +24,8 @@ use Piwik\Plugins\ConnectAccounts\ConnectAccounts;
 use Piwik\Plugins\Referrers\API;
 use Piwik\Plugins\ConnectAccounts\helpers\ConnectHelper;
 use Piwik\Plugins\ConnectAccounts\Strategy\Google\GoogleConnect;
+use Piwik\Plugins\UsersManager\UserPreferences;
+use Piwik\Request;
 use Piwik\SettingsPiwik;
 use Piwik\Url;
 use Piwik\Site;
@@ -575,6 +577,11 @@ class GoogleAnalyticsImporter extends \Piwik\Plugin
                     'strategy' => GoogleConnect::getStrategyName()
                 ]);
         }
+        $idSite = Request::fromRequest()->getIntegerParameter('idSite', 0);
+        // If for some reason the idSite query parameter isn't set, look up the default site ID
+        if ($idSite < 1) {
+            $idSite = StaticContainer::get(UserPreferences::class)->getDefaultWebsiteId();
+        }
         return  [
             'isConnectAccountsActivated' => $isConnectAccountsActivated,
             'primaryText' => Piwik::translate('GoogleAnalyticsImporter_ConfigureTheImporterLabel1'),
@@ -592,7 +599,7 @@ class GoogleAnalyticsImporter extends \Piwik\Plugin
             'manualActionUrl' => Url::getCurrentUrlWithoutQueryString() . '?' . Http::buildQuery([
                     'module' => 'GoogleAnalyticsImporter',
                     'action' => 'configureClient',
-                    'idSite' => Common::getRequestVar('idSite'),
+                    'idSite' => $idSite,
                 ]),
             'connectAccountsUrl' => $googleAuthUrl,
             'connectAccountsBtnText' => Piwik::translate('ConnectAccounts_ConnectWithGoogleText'),


### PR DESCRIPTION
### Description:

While testing Matomo Cloud 5.x, I found that a 500 error occurred if I clicked cancel during the OAuth process. This remedies that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
