### PR TITLE
streamId is not a valid option in system test

### DIFF
--- a/tests/Fixtures/ImportedFromGoogleGA4.php
+++ b/tests/Fixtures/ImportedFromGoogleGA4.php
@@ -176,7 +176,7 @@ class ImportedFromGoogleGA4 extends Fixture
         if ($idSiteToResume) {
             $command .= '--idsite=' . $idSiteToResume;
         } else {
-            $command .= ' --dates=' . $dates . ' --property=' . $property . ' --streamId='.$streamIds.' --extra-custom-dimension=userAgeBracket,visit';
+            $command .= ' --dates=' . $dates . ' --property=' . $property . ' --streamIds='.$streamIds.' --extra-custom-dimension=userAgeBracket,visit';
         }
 
         $timer = new Timer();


### PR DESCRIPTION
### Description:

When running ImportedFromGoogleGA4 locally I got the above error. It seems the code uses --streamId=..., but only --streamIds is supported by the command.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
