### PR TITLE
Added tests to check direct use of core dependencies, #PG-3272

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           lfs: true
           persist-credentials: false
+      - name: Install package ripgrep
+        run: sudo apt-get install ripgrep
       - name: Run tests
         uses: matomo-org/github-action-tests@main
         with:

--- a/tests/System/CheckDirectDependencyUseCommandTest.php
+++ b/tests/System/CheckDirectDependencyUseCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\GoogleAnalyticsImporter\tests\System;
+
+use Piwik\Plugins\TestRunner\Commands\CheckDirectDependencyUse;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Version;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CheckDirectDependencyUseCommandTest extends SystemTestCase
+{
+    public function testCommand()
+    {
+        if (version_compare(Version::VERSION, '5.0.2', '<=') && !\Piwik\file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
+            $this->markTestSkipped('tests:check-direct-dependency-use is not available in this version');
+        }
+        $pluginName = 'GoogleAnalyticsImporter';
+        $console = new \Piwik\Console(self::$fixture->piwikEnvironment);
+        $checkDirectDependencyUse = new CheckDirectDependencyUse();
+        $console->addCommands([$checkDirectDependencyUse]);
+        $command = $console->find('tests:check-direct-dependency-use');
+        $arguments = array(
+            'command'    => 'tests:check-direct-dependency-use',
+            '--plugin' => $pluginName,
+            '--grep-vendor'
+        );
+        $inputObject = new ArrayInput($arguments);
+        $command->run($inputObject, new NullOutput());
+
+        $this->assertEquals([
+            'Matomo\Cache\\' => [
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
+            ],
+            'DeviceDetector\\' => [
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
+            ],
+            'Monolog\\' => [
+                'GoogleAnalyticsImporter/Monolog/Handler/GASystemLogHandler.php'
+            ],
+            'Symfony\Component\Console\\' => [
+                'GoogleAnalyticsImporter/tests/System/CheckDirectDependencyUseCommandTest.php'
+            ],
+            'Symfony\Bridge\Monolog\\' => [
+                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogle.php',
+                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogleGA4.php'
+            ],
+            'Twig\\' => [
+                'GoogleAnalyticsImporter/Controller.php'
+            ]
+        ], $checkDirectDependencyUse->usesFoundList[$pluginName]);
+    }
+}

--- a/tests/System/CheckDirectDependencyUseCommandTest.php
+++ b/tests/System/CheckDirectDependencyUseCommandTest.php
@@ -18,7 +18,7 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
 {
     public function testCommand()
     {
-        if (version_compare(Version::VERSION, '5.0.2', '<=') && !\Piwik\file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
+        if (version_compare(Version::VERSION, '5.0.2', '<=') && !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
             $this->markTestSkipped('tests:check-direct-dependency-use is not available in this version');
         }
         $pluginName = 'GoogleAnalyticsImporter';
@@ -35,27 +35,6 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
         $command->run($inputObject, new NullOutput());
 
         $this->assertEquals([
-            'Matomo\Cache\\' => [
-                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
-                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
-            ],
-            'DeviceDetector\\' => [
-                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
-                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
-            ],
-            'Monolog\\' => [
-                'GoogleAnalyticsImporter/Monolog/Handler/GASystemLogHandler.php'
-            ],
-            'Symfony\Component\Console\\' => [
-                'GoogleAnalyticsImporter/tests/System/CheckDirectDependencyUseCommandTest.php'
-            ],
-            'Symfony\Bridge\Monolog\\' => [
-                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogle.php',
-                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogleGA4.php'
-            ],
-            'Twig\\' => [
-                'GoogleAnalyticsImporter/Controller.php'
-            ]
         ], $checkDirectDependencyUse->usesFoundList[$pluginName]);
     }
 }

--- a/tests/System/CheckDirectDependencyUseCommandTest.php
+++ b/tests/System/CheckDirectDependencyUseCommandTest.php
@@ -18,7 +18,7 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
 {
     public function testCommand()
     {
-        if (version_compare(Version::VERSION, '5.0.2', '<=') && !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
+        if (version_compare(Version::VERSION, '5.0.3', '<=') && !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
             $this->markTestSkipped('tests:check-direct-dependency-use is not available in this version');
         }
         $pluginName = 'GoogleAnalyticsImporter';
@@ -35,6 +35,27 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
         $command->run($inputObject, new NullOutput());
 
         $this->assertEquals([
+            'Matomo\Cache' => [
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
+            ],
+            'DeviceDetector' => [
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporter.php',
+                'GoogleAnalyticsImporter/Importers/DevicesDetection/RecordImporterGA4.php'
+            ],
+            'Monolog' => [
+                'GoogleAnalyticsImporter/Monolog/Handler/GASystemLogHandler.php'
+            ],
+            'Symfony\Component\Console' => [
+                'GoogleAnalyticsImporter/tests/System/CheckDirectDependencyUseCommandTest.php'
+            ],
+            'Symfony\Bridge\Monolog' => [
+                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogle.php',
+                'GoogleAnalyticsImporter/tests/Fixtures/ImportedFromGoogleGA4.php'
+            ],
+            'Twig' => [
+                'GoogleAnalyticsImporter/Controller.php'
+            ]
         ], $checkDirectDependencyUse->usesFoundList[$pluginName]);
     }
 }


### PR DESCRIPTION
### Description:

Added tests to check direct use of core dependencies
Fixes: #PG-3272
Depends on: https://github.com/matomo-org/matomo/pull/21969

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
