### PR TITLE
Change db backoff due to rate limit per site instead of setting it globally, #PG-2588

### DIFF
--- a/Commands/ImportGA4Reports.php
+++ b/Commands/ImportGA4Reports.php
@@ -77,7 +77,7 @@ class ImportGA4Reports extends ConsoleCommand
         LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite, $output);
         /** @var ImportStatus $importStatus */
         $importStatus = StaticContainer::get(ImportStatus::class);
-        $canProcessNow = $this->checkIfCanProcess();
+        $canProcessNow = $this->checkIfCanProcess($idSite);
         if ($canProcessNow['canProcess'] === \false) {
             $exceededMessage = 'The import was rate limited and will be restarted automatically at ' . $canProcessNow['nextAvailableAt'];
             if (!empty($canProcessNow['rateLimitType']) && $canProcessNow['rateLimitType'] === 'hourly') {
@@ -332,14 +332,18 @@ class ImportGA4Reports extends ConsoleCommand
             throw new \Exception("Invalid property ID, required format properties/{propertyID}");
         }
     }
-    public function checkIfCanProcess()
+    public function checkIfCanProcess($idSite)
     {
-        $nextAvailableAt = (int) Option::get(GoogleAnalyticsGA4QueryService::DELAY_OPTION_NAME);
+        if (!$idSite) {
+            return true; // New import, so it should be allowed
+        }
+        $optionKeyName = GoogleAnalyticsGA4QueryService::DELAY_OPTION_NAME . $idSite;
+        $nextAvailableAt = (int) Option::get($optionKeyName);
         if (!$nextAvailableAt) {
             return ['canProcess' => \true];
         }
         if (Date::factory('now')->getTimestamp() >= $nextAvailableAt) {
-            Option::delete(GoogleAnalyticsGA4QueryService::DELAY_OPTION_NAME);
+            Option::delete($optionKeyName);
             return ['canProcess' => \true];
         }
         $rateLimitType = Date::factory('+1 hour')->getTimestamp() > $nextAvailableAt ? 'hourly' : 'daily';

--- a/Commands/ImportGA4Reports.php
+++ b/Commands/ImportGA4Reports.php
@@ -335,7 +335,7 @@ class ImportGA4Reports extends ConsoleCommand
     public function checkIfCanProcess($idSite)
     {
         if (!$idSite) {
-            return true; // New import, so it should be allowed
+            return ['canProcess' => \true]; // New import, so it should be allowed
         }
         $optionKeyName = GoogleAnalyticsGA4QueryService::DELAY_OPTION_NAME . $idSite;
         $nextAvailableAt = (int) Option::get($optionKeyName);

--- a/Commands/ImportReports.php
+++ b/Commands/ImportReports.php
@@ -370,7 +370,7 @@ class ImportReports extends ConsoleCommand
     public function checkIfCanProcess($idSite)
     {
         if (!$idSite) {
-            return true; // New import, so it should be allowed
+            return ['canProcess' => \true];// New import, so it should be allowed
         }
         $optionKeyName = GoogleAnalyticsQueryService::DELAY_OPTION_NAME . $idSite;
         $nextAvailableAt = (int) Option::get($optionKeyName);

--- a/Commands/ImportReports.php
+++ b/Commands/ImportReports.php
@@ -78,7 +78,7 @@ class ImportReports extends ConsoleCommand
         $type = $isMobileApp ? \Piwik\Plugins\MobileAppMeasurable\Type::ID : Type::ID;
         $idSite = $this->getIdSite();
         LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite, $output);
-        $canProcessNow = $this->checkIfCanProcess();
+        $canProcessNow = $this->checkIfCanProcess($idSite);
         /** @var ImportStatus $importStatus */
         $importStatus = StaticContainer::get(ImportStatus::class);
         if ($canProcessNow['canProcess'] === \false) {
@@ -367,14 +367,18 @@ class ImportReports extends ConsoleCommand
             return \false;
         }
     }
-    public function checkIfCanProcess()
+    public function checkIfCanProcess($idSite)
     {
-        $nextAvailableAt = (int) Option::get(GoogleAnalyticsQueryService::DELAY_OPTION_NAME);
+        if (!$idSite) {
+            return true; // New import, so it should be allowed
+        }
+        $optionKeyName = GoogleAnalyticsQueryService::DELAY_OPTION_NAME . $idSite;
+        $nextAvailableAt = (int) Option::get($optionKeyName);
         if (!$nextAvailableAt) {
             return ['canProcess' => \true];
         }
         if (Date::factory('now')->getTimestamp() >= $nextAvailableAt) {
-            Option::delete(GoogleAnalyticsQueryService::DELAY_OPTION_NAME);
+            Option::delete($optionKeyName);
             return ['canProcess' => \true];
         }
         $rateLimitType = Date::factory('+1 hour')->getTimestamp() > $nextAvailableAt ? 'hourly' : 'daily';

--- a/Google/GoogleAnalyticsGA4QueryService.php
+++ b/Google/GoogleAnalyticsGA4QueryService.php
@@ -27,7 +27,7 @@ class GoogleAnalyticsGA4QueryService
     const PING_MYSQL_EVERY = 25;
     const DEFAULT_MIN_BACKOFF_TIME = 2;
     // start at 2s since GA seems to have trouble w/ the 10 requests per 100s limit w/ 1
-    const DELAY_OPTION_NAME = 'GoogleAnalyticsImporter_nextAvailableAt';
+    const DELAY_OPTION_NAME = 'GoogleAnalyticsImporter_nextAvailableAt_';
     private static $problematicMetrics = ['totalUsers', 'eventCount'];
     /**
      * @var int
@@ -76,6 +76,8 @@ class GoogleAnalyticsGA4QueryService
     private $quotaUser;
     private $skipAttemptForExceptionCodes = [401, 403];
     private $singleAttemptForExceptionCodes = [500, 503];
+
+    private $idSite;
     public function __construct(BetaAnalyticsDataClient $gaClient, AnalyticsAdminServiceClient $gaAdminClient, $propertyId, array $goalsMapping, $idSite, $quotaUser, \Piwik\Plugins\GoogleAnalyticsImporter\Google\GoogleGA4QueryObjectFactory $googleGA4QueryObjectFactory, LoggerInterface $logger, $streamIds = [])
     {
         $this->gaClient = $gaClient;
@@ -87,6 +89,7 @@ class GoogleAnalyticsGA4QueryService
         $this->metricMapper = new GoogleGA4MetricMapper(Site::isEcommerceEnabledFor($idSite), $goalsMapping);
         $this->quotaUser = $quotaUser;
         $this->streamIds = $streamIds;
+        $this->idSite = $idSite;
     }
     public function query(Date $day, array $dimensions, array $metrics, array $options = [])
     {
@@ -265,7 +268,7 @@ class GoogleAnalyticsGA4QueryService
         if ($backoffLength === 'D') {
             $nextRetry = Date::factory('tomorrow')->getTimestamp();
         }
-        Option::set(self::DELAY_OPTION_NAME, $nextRetry);
+        Option::set(self::DELAY_OPTION_NAME . $this->idSite, $nextRetry);
     }
     private function isIgnorableException(\Exception $ex)
     {

--- a/Google/GoogleAnalyticsQueryService.php
+++ b/Google/GoogleAnalyticsQueryService.php
@@ -25,7 +25,7 @@ class GoogleAnalyticsQueryService
     const PING_MYSQL_EVERY = 25;
     const DEFAULT_MIN_BACKOFF_TIME = 2;
     // start at 2s since GA seems to have trouble w/ the 10 requests per 100s limit w/ 1
-    const DELAY_OPTION_NAME = 'GoogleAnalyticsImporter_nextAvailableAt';
+    const DELAY_OPTION_NAME = 'GoogleAnalyticsImporter_nextAvailableAt_';
     private static $problematicMetrics = ['ga:users', 'ga:hits'];
     /**
      * @var int
@@ -66,6 +66,8 @@ class GoogleAnalyticsQueryService
     private $quotaUser;
     private $skipAttemptForExceptionCodes = [401, 403];
     private $singleAttemptForExceptionCodes = [500, 503];
+
+    private $idSite;
     public function __construct(\Matomo\Dependencies\GoogleAnalyticsImporter\Google\Service\AnalyticsReporting $gaService, $viewId, array $goalsMapping, $idSite, $quotaUser, \Piwik\Plugins\GoogleAnalyticsImporter\Google\GoogleQueryObjectFactory $googleQueryObjectFactory, LoggerInterface $logger)
     {
         $this->gaService = $gaService;
@@ -75,6 +77,7 @@ class GoogleAnalyticsQueryService
         $this->pingMysqlEverySecs = StaticContainer::get('GoogleAnalyticsImporter.pingMysqlEverySecs') ?: self::PING_MYSQL_EVERY;
         $this->metricMapper = new \Piwik\Plugins\GoogleAnalyticsImporter\Google\GoogleMetricMapper(Site::isEcommerceEnabledFor($idSite), $goalsMapping);
         $this->quotaUser = $quotaUser;
+        $this->idSite = $idSite;
     }
     public function query(Date $day, array $dimensions, array $metrics, array $options = [])
     {
@@ -125,6 +128,7 @@ class GoogleAnalyticsQueryService
         $skipReAttempt = \false;
         while ($attempts < $this->maxAttempts) {
             try {
+                throw new \Exception('daily limit reached', 429);
                 $this->issuePointlessMysqlQuery();
                 $result = $this->gaService->reports->batchGet($request, ['quotaUser' => $this->quotaUser]);
                 // @TODO if result->reports[0]->nextPageToken returns a value
@@ -255,6 +259,6 @@ class GoogleAnalyticsQueryService
         if ($backoffLength === 'D') {
             $nextRetry = Date::factory('tomorrow')->getTimestamp();
         }
-        Option::set(self::DELAY_OPTION_NAME, $nextRetry);
+        Option::set(self::DELAY_OPTION_NAME . $this->idSite, $nextRetry);
     }
 }

--- a/Google/GoogleAnalyticsQueryService.php
+++ b/Google/GoogleAnalyticsQueryService.php
@@ -128,7 +128,6 @@ class GoogleAnalyticsQueryService
         $skipReAttempt = \false;
         while ($attempts < $this->maxAttempts) {
             try {
-                throw new \Exception('daily limit reached', 429);
                 $this->issuePointlessMysqlQuery();
                 $result = $this->gaService->reports->batchGet($request, ['quotaUser' => $this->quotaUser]);
                 // @TODO if result->reports[0]->nextPageToken returns a value

--- a/tests/Framework/BaseRecordImporterTest.php
+++ b/tests/Framework/BaseRecordImporterTest.php
@@ -18,6 +18,8 @@ use Piwik\Plugins\GoogleAnalyticsImporter\RecordInserter;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Log\NullLogger;
+use Piwik\Version;
+
 abstract class BaseRecordImporterTest extends IntegrationTestCase
 {
     /**
@@ -93,8 +95,12 @@ abstract class BaseRecordImporterTest extends IntegrationTestCase
         $testFilesDirectory = $this->getTestDir() . '/..';
         $processedDir = $testFilesDirectory . '/processed/';
         $expectedDir = $testFilesDirectory . '/expected/';
-        $expectedFilePath = $expectedDir . $testName . '.xml';
-        $processedFilePath = $processedDir . $testName . '.xml';
+        $appendOld = '';
+        if (version_compare(Version::VERSION, '5.1.0-rc1') <= 0) {
+            $appendOld = '_old';
+        }
+        $expectedFilePath = $expectedDir . $testName . $appendOld . '.xml';
+        $processedFilePath = $processedDir . $testName . $appendOld . '.xml';
         $this->ensureDirectory($processedDir);
         $this->ensureDirectory($expectedDir);
         $renderer = new Xml();

--- a/tests/Integration/DbBackOffTest.php
+++ b/tests/Integration/DbBackOffTest.php
@@ -43,10 +43,10 @@ class DbBackOffTest extends IntegrationTestCase
         $builder = $this->getMockBuilder(\Matomo\Dependencies\GoogleAnalyticsImporter\Google\Service\AnalyticsReporting\Resource\Reports::class);
         $mockReportingService->reports = $builder->disableOriginalConstructor()->onlyMethods(['batchGet'])->getMock();
         $this->getMockBuilder(\Matomo\Dependencies\GoogleAnalyticsImporter\Google\Service\AnalyticsReporting::class);
-        $gaQueryService = new GoogleAnalyticsQueryService($mockReportingService, 'testviewid', [], 1, 'testuser', StaticContainer::get(GoogleQueryObjectFactory::class), StaticContainer::get(LoggerInterface::class));
+        $gaQueryService = new GoogleAnalyticsQueryService($mockReportingService, 'testviewid', [], $idSite = 1, 'testuser', StaticContainer::get(GoogleQueryObjectFactory::class), StaticContainer::get(LoggerInterface::class));
         $gaQueryService->setDbBackOff();
-        $this->assertSame(Date::factory('+1 hour')->toString('Y-m-d H:i'), Date::factory(Option::get(GoogleAnalyticsQueryService::DELAY_OPTION_NAME))->toString('Y-m-d H:i'));
+        $this->assertSame(Date::factory('+1 hour')->toString('Y-m-d H:i'), Date::factory(Option::get(GoogleAnalyticsQueryService::DELAY_OPTION_NAME . $idSite))->toString('Y-m-d H:i'));
         $gaQueryService->setDbBackOff('D');
-        $this->assertSame(Date::factory('tomorrow')->toString('Y-m-d H:i'), Date::factory(Option::get(GoogleAnalyticsQueryService::DELAY_OPTION_NAME))->toString('Y-m-d H:i'));
+        $this->assertSame(Date::factory('tomorrow')->toString('Y-m-d H:i'), Date::factory(Option::get(GoogleAnalyticsQueryService::DELAY_OPTION_NAME . $idSite))->toString('Y-m-d H:i'));
     }
 }

--- a/tests/Integration/Importers/expected/Actions_basicImport_old.xml
+++ b/tests/Integration/Importers/expected/Actions_basicImport_old.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="Actions_SiteSearchCategories">
+		<row>
+			<label>cat1</label>
+		</row>
+		<row>
+			<label>cat2</label>
+		</row>
+		<row>
+			<label>cat3</label>
+		</row>
+	</result>
+	<result record="Actions_actions">
+		<row>
+			<col name="label"> Index real</col>
+			<col name="2">3</col>
+			<col name="1">9</col>
+			<col name="12">19</col>
+			<col name="13">2</col>
+			<col name="30">5</col>
+			<col name="31">7</col>
+			<col name="19">4</col>
+			<col name="20">5</col>
+			<col name="21">6</col>
+			<col name="22">7</col>
+			<col name="15">4</col>
+		</row>
+		<row>
+			<col name="label"> A Page</col>
+			<col name="2">16</col>
+			<col name="1">15</col>
+			<col name="12">18</col>
+			<col name="13">1</col>
+			<col name="30">2</col>
+			<col name="31">4</col>
+		</row>
+		<row>
+			<col name="label"> Index page</col>
+			<col name="2">14</col>
+			<col name="1">7</col>
+			<col name="12">2</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">3</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="15">3</col>
+		</row>
+		<row>
+			<col name="label"> A Folder &gt; Page</col>
+			<col name="2">20</col>
+			<col name="1">10</col>
+			<col name="12">1</col>
+			<col name="13">1</col>
+			<col name="30">1</col>
+			<col name="31">1</col>
+			<col name="15">1</col>
+		</row>
+	</result>
+	<result record="Actions_actions_url">
+		<row>
+			<col name="label">/index</col>
+			<col name="2">1</col>
+			<col name="1">2</col>
+			<col name="12">24</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="url">http://piwik.net/</col>
+		</row>
+		<row>
+			<col name="label">/index</col>
+			<col name="2">6</col>
+			<col name="1">5</col>
+			<col name="12">18</col>
+			<col name="13">10</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="url">http://piwik.net/index</col>
+		</row>
+		<row>
+			<col name="label">folder</col>
+			<col name="2">7</col>
+			<col name="12">21</col>
+			<col name="13">16</col>
+			<col name="30">3</col>
+			<col name="31">2</col>
+			<col name="folder_url_start">folder</col>
+			<col name="idsubdatatable">19</col>
+			<col name="subtable">
+				<row>
+					<col name="label">/index#ahashvalue</col>
+					<col name="2">0</col>
+					<col name="1">0</col>
+					<col name="12">12</col>
+					<col name="13">6</col>
+					<col name="30">1</col>
+					<col name="31">1</col>
+					<col name="url">http://piwik.net/folder/#ahashvalue</col>
+				</row>
+				<row>
+					<col name="label">/page</col>
+					<col name="2">7</col>
+					<col name="1">7</col>
+					<col name="12">9</col>
+					<col name="13">10</col>
+					<col name="30">2</col>
+					<col name="31">1</col>
+					<col name="url">http://piwik.net/folder/page</col>
+				</row>
+			</col>
+		</row>
+		<row>
+			<col name="label">/apage</col>
+			<col name="2">14</col>
+			<col name="1">4</col>
+			<col name="12">10</col>
+			<col name="13">5</col>
+			<col name="30">2</col>
+			<col name="31">6</col>
+			<col name="url">http://piwik.net/apage</col>
+		</row>
+	</result>
+	<result record="Actions_sitesearch">
+		<row>
+			<col name="label">serach 5</col>
+			<col name="2">10</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 6</col>
+			<col name="2">8</col>
+			<col name="1">4</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+		<row>
+			<col name="label">serach 2</col>
+			<col name="2">1</col>
+			<col name="1">1</col>
+			<col name="12">0</col>
+			<col name="13">0</col>
+		</row>
+	</result>
+	<result record="Actions_nb_pageviews">
+		<row>
+			<value>73</value>
+		</row>
+	</result>
+	<result record="Actions_nb_uniq_pageviews">
+		<row>
+			<value>28</value>
+		</row>
+	</result>
+	<result record="Actions_sum_time_generation">
+		<row>
+			<value>11</value>
+		</row>
+	</result>
+	<result record="Actions_nb_hits_with_time_generation">
+		<row>
+			<value>16</value>
+		</row>
+	</result>
+	<result record="Actions_nb_searches">
+		<row>
+			<value>0</value>
+		</row>
+	</result>
+	<result record="Actions_nb_keywords">
+		<row>
+			<value>3</value>
+		</row>
+	</result>
+</results>

--- a/tests/Integration/Importers/expected/Actions_mobileApp_old.xml
+++ b/tests/Integration/Importers/expected/Actions_mobileApp_old.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="Actions_SiteSearchCategories">
+		<row>
+			<label>cat1</label>
+		</row>
+		<row>
+			<label>cat2</label>
+		</row>
+		<row>
+			<label>cat3</label>
+		</row>
+	</result>
+	<result record="Actions_actions">
+		<row>
+			<col name="label"> Homepage</col>
+			<col name="2">32</col>
+			<col name="1">30</col>
+			<col name="12">38</col>
+			<col name="13">4</col>
+			<col name="30">10</col>
+			<col name="31">14</col>
+			<col name="17">7</col>
+			<col name="19">8</col>
+			<col name="20">9</col>
+			<col name="21">10</col>
+			<col name="22">11</col>
+			<col name="14">4</col>
+			<col name="15">4</col>
+		</row>
+		<row>
+			<col name="label"> A Screen</col>
+			<col name="2">20</col>
+			<col name="1">10</col>
+			<col name="12">18</col>
+			<col name="13">1</col>
+			<col name="30">2</col>
+			<col name="31">4</col>
+		</row>
+		<row>
+			<col name="label"> Another Screen &gt; Sub Screen</col>
+			<col name="2">3</col>
+			<col name="1">9</col>
+			<col name="12">2</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">3</col>
+			<col name="14">1</col>
+			<col name="15">1</col>
+		</row>
+		<row>
+			<col name="label"> Third Screen</col>
+			<col name="2">14</col>
+			<col name="1">7</col>
+			<col name="12">1</col>
+			<col name="13">1</col>
+			<col name="30">1</col>
+			<col name="31">1</col>
+			<col name="17">2</col>
+			<col name="19">3</col>
+			<col name="20">4</col>
+			<col name="21">5</col>
+			<col name="22">6</col>
+			<col name="14">2</col>
+			<col name="15">2</col>
+		</row>
+	</result>
+	<result record="Actions_actions_url" />
+	<result record="Actions_sitesearch" />
+	<result record="Actions_nb_pageviews">
+		<row>
+			<value>59</value>
+		</row>
+	</result>
+	<result record="Actions_nb_uniq_pageviews">
+		<row>
+			<value>69</value>
+		</row>
+	</result>
+	<result record="Actions_sum_time_generation">
+		<row>
+			<value>16</value>
+		</row>
+	</result>
+	<result record="Actions_nb_hits_with_time_generation">
+		<row>
+			<value>22</value>
+		</row>
+	</result>
+	<result record="Actions_nb_searches">
+		<row>
+			<value>0</value>
+		</row>
+	</result>
+	<result record="Actions_nb_keywords">
+		<row>
+			<value>0</value>
+		</row>
+	</result>
+</results>

--- a/tests/Integration/Importers/expected/CustomDimensions_basicImport.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_basicImport.xml
@@ -1,59 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="12">11</col>
+			<col name="13">22</col>
+			<col name="30">33</col>
+			<col name="31">44</col>
+			<col name="label">__not_set_in_google_analytics__</col>
+		</row>
+	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
-			<col name="12">10</col>
-			<col name="13">20</col>
-			<col name="30">30</col>
-			<col name="31">40</col>
-			<col name="label">v1</col>
 			<col name="2">8</col>
 			<col name="6">3</col>
+			<col name="label">v1</col>
 			<col name="15">6</col>
 			<col name="19">9</col>
 			<col name="20">3</col>
 			<col name="21">1</col>
 		</row>
 		<row>
-			<col name="12">1</col>
-			<col name="13">2</col>
-			<col name="30">3</col>
-			<col name="31">4</col>
-			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">3</col>
+			<col name="label">v2</col>
 			<col name="15">4</col>
 			<col name="19">7</col>
 			<col name="20">4</col>
 			<col name="21">4</col>
-		</row>
-	</result>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="1">4</col>
-			<col name="2">6</col>
-			<col name="3">3</col>
-			<col name="5">2</col>
-			<col name="6">2</col>
-			<col name="7">1</col>
-			<col name="8">1</col>
-			<col name="9">3</col>
-			<col name="10">
-			</col>
-			<col name="label">value 1</col>
-		</row>
-		<row>
-			<col name="1">3</col>
-			<col name="2">3</col>
-			<col name="3">1</col>
-			<col name="5">200</col>
-			<col name="6">0</col>
-			<col name="7">1</col>
-			<col name="8">1</col>
-			<col name="9">1</col>
-			<col name="10">
-			</col>
-			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_basicImport.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_basicImport.xml
@@ -1,32 +1,59 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="12">11</col>
-			<col name="13">22</col>
-			<col name="30">33</col>
-			<col name="31">44</col>
-			<col name="label">__not_set_in_google_analytics__</col>
-		</row>
-	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
+			<col name="12">10</col>
+			<col name="13">20</col>
+			<col name="30">30</col>
+			<col name="31">40</col>
+			<col name="label">v1</col>
 			<col name="2">8</col>
 			<col name="6">3</col>
-			<col name="label">v1</col>
 			<col name="15">6</col>
 			<col name="19">9</col>
 			<col name="20">3</col>
 			<col name="21">1</col>
 		</row>
 		<row>
+			<col name="12">1</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">3</col>
-			<col name="label">v2</col>
 			<col name="15">4</col>
 			<col name="19">7</col>
 			<col name="20">4</col>
 			<col name="21">4</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">4</col>
+			<col name="2">6</col>
+			<col name="3">3</col>
+			<col name="5">2</col>
+			<col name="6">2</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">3</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">3</col>
+			<col name="2">3</col>
+			<col name="3">1</col>
+			<col name="5">200</col>
+			<col name="6">0</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_basicImport_old.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_basicImport_old.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="CustomDimensions_Dimension2">
+		<row>
+			<col name="12">10</col>
+			<col name="13">20</col>
+			<col name="30">30</col>
+			<col name="31">40</col>
+			<col name="label">v1</col>
+			<col name="2">8</col>
+			<col name="6">3</col>
+			<col name="15">6</col>
+			<col name="19">9</col>
+			<col name="20">3</col>
+			<col name="21">1</col>
+		</row>
+		<row>
+			<col name="12">1</col>
+			<col name="13">2</col>
+			<col name="30">3</col>
+			<col name="31">4</col>
+			<col name="label">v2</col>
+			<col name="2">6</col>
+			<col name="6">3</col>
+			<col name="15">4</col>
+			<col name="19">7</col>
+			<col name="20">4</col>
+			<col name="21">4</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">4</col>
+			<col name="2">6</col>
+			<col name="3">3</col>
+			<col name="5">2</col>
+			<col name="6">2</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">3</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">3</col>
+			<col name="2">3</col>
+			<col name="3">1</col>
+			<col name="5">200</col>
+			<col name="6">0</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
+		</row>
+	</result>
+</results>

--- a/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions.xml
@@ -1,59 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="12">12</col>
+			<col name="13">12</col>
+			<col name="30">12</col>
+			<col name="31">12</col>
+			<col name="label">__not_set_in_google_analytics__</col>
+		</row>
+	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
-			<col name="12">8</col>
-			<col name="13">8</col>
-			<col name="30">8</col>
-			<col name="31">8</col>
-			<col name="label">v1</col>
 			<col name="2">9</col>
 			<col name="6">7</col>
+			<col name="label">v1</col>
 			<col name="15">5</col>
 			<col name="19">7</col>
 			<col name="20">6</col>
 			<col name="21">5</col>
 		</row>
 		<row>
-			<col name="12">4</col>
-			<col name="13">4</col>
-			<col name="30">4</col>
-			<col name="31">4</col>
-			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">5</col>
+			<col name="label">v2</col>
 			<col name="15">2</col>
 			<col name="19">4</col>
 			<col name="20">3</col>
 			<col name="21">2</col>
-		</row>
-	</result>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="1">5</col>
-			<col name="2">5</col>
-			<col name="3">5</col>
-			<col name="5">5</col>
-			<col name="6">5</col>
-			<col name="7">5</col>
-			<col name="8">5</col>
-			<col name="9">5</col>
-			<col name="10">
-			</col>
-			<col name="label">value 1</col>
-		</row>
-		<row>
-			<col name="1">3</col>
-			<col name="2">3</col>
-			<col name="3">3</col>
-			<col name="5">3</col>
-			<col name="6">3</col>
-			<col name="7">1</col>
-			<col name="8">1</col>
-			<col name="9">1</col>
-			<col name="10">
-			</col>
-			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions.xml
@@ -1,32 +1,59 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="12">12</col>
-			<col name="13">12</col>
-			<col name="30">12</col>
-			<col name="31">12</col>
-			<col name="label">__not_set_in_google_analytics__</col>
-		</row>
-	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
+			<col name="12">8</col>
+			<col name="13">8</col>
+			<col name="30">8</col>
+			<col name="31">8</col>
+			<col name="label">v1</col>
 			<col name="2">9</col>
 			<col name="6">7</col>
-			<col name="label">v1</col>
 			<col name="15">5</col>
 			<col name="19">7</col>
 			<col name="20">6</col>
 			<col name="21">5</col>
 		</row>
 		<row>
+			<col name="12">4</col>
+			<col name="13">4</col>
+			<col name="30">4</col>
+			<col name="31">4</col>
+			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">5</col>
-			<col name="label">v2</col>
 			<col name="15">2</col>
 			<col name="19">4</col>
 			<col name="20">3</col>
 			<col name="21">2</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">5</col>
+			<col name="2">5</col>
+			<col name="3">5</col>
+			<col name="5">5</col>
+			<col name="6">5</col>
+			<col name="7">5</col>
+			<col name="8">5</col>
+			<col name="9">5</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">3</col>
+			<col name="2">3</col>
+			<col name="3">3</col>
+			<col name="5">3</col>
+			<col name="6">3</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions_old.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_extraCustomDimensions_old.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="CustomDimensions_Dimension2">
+		<row>
+			<col name="12">8</col>
+			<col name="13">8</col>
+			<col name="30">8</col>
+			<col name="31">8</col>
+			<col name="label">v1</col>
+			<col name="2">9</col>
+			<col name="6">7</col>
+			<col name="15">5</col>
+			<col name="19">7</col>
+			<col name="20">6</col>
+			<col name="21">5</col>
+		</row>
+		<row>
+			<col name="12">4</col>
+			<col name="13">4</col>
+			<col name="30">4</col>
+			<col name="31">4</col>
+			<col name="label">v2</col>
+			<col name="2">6</col>
+			<col name="6">5</col>
+			<col name="15">2</col>
+			<col name="19">4</col>
+			<col name="20">3</col>
+			<col name="21">2</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">5</col>
+			<col name="2">5</col>
+			<col name="3">5</col>
+			<col name="5">5</col>
+			<col name="6">5</col>
+			<col name="7">5</col>
+			<col name="8">5</col>
+			<col name="9">5</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">3</col>
+			<col name="2">3</col>
+			<col name="3">3</col>
+			<col name="5">3</col>
+			<col name="6">3</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
+		</row>
+	</result>
+</results>

--- a/tests/Integration/Importers/expected/CustomDimensions_mobileApp.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_mobileApp.xml
@@ -1,59 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="12">16</col>
+			<col name="13">16</col>
+			<col name="30">13</col>
+			<col name="31">13</col>
+			<col name="label">__not_set_in_google_analytics__</col>
+		</row>
+	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
-			<col name="12">10</col>
-			<col name="13">10</col>
-			<col name="30">8</col>
-			<col name="31">8</col>
-			<col name="label">v1</col>
 			<col name="2">19</col>
 			<col name="6">17</col>
+			<col name="label">v1</col>
 			<col name="15">25</col>
 			<col name="19">10</col>
 			<col name="20">7</col>
 			<col name="21">4</col>
 		</row>
 		<row>
-			<col name="12">6</col>
-			<col name="13">6</col>
-			<col name="30">5</col>
-			<col name="31">5</col>
-			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">5</col>
+			<col name="label">v2</col>
 			<col name="15">12</col>
 			<col name="19">7</col>
 			<col name="20">2</col>
 			<col name="21">2</col>
-		</row>
-	</result>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="1">8</col>
-			<col name="2">7</col>
-			<col name="3">6</col>
-			<col name="5">5</col>
-			<col name="6">4</col>
-			<col name="7">3</col>
-			<col name="8">2</col>
-			<col name="9">1</col>
-			<col name="10">
-			</col>
-			<col name="label">value 1</col>
-		</row>
-		<row>
-			<col name="1">6</col>
-			<col name="2">5</col>
-			<col name="3">4</col>
-			<col name="5">3</col>
-			<col name="6">2</col>
-			<col name="7">1</col>
-			<col name="8">1</col>
-			<col name="9">1</col>
-			<col name="10">
-			</col>
-			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_mobileApp.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_mobileApp.xml
@@ -1,32 +1,59 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
-	<result record="CustomDimensions_Dimension1">
-		<row>
-			<col name="12">16</col>
-			<col name="13">16</col>
-			<col name="30">13</col>
-			<col name="31">13</col>
-			<col name="label">__not_set_in_google_analytics__</col>
-		</row>
-	</result>
 	<result record="CustomDimensions_Dimension2">
 		<row>
+			<col name="12">10</col>
+			<col name="13">10</col>
+			<col name="30">8</col>
+			<col name="31">8</col>
+			<col name="label">v1</col>
 			<col name="2">19</col>
 			<col name="6">17</col>
-			<col name="label">v1</col>
 			<col name="15">25</col>
 			<col name="19">10</col>
 			<col name="20">7</col>
 			<col name="21">4</col>
 		</row>
 		<row>
+			<col name="12">6</col>
+			<col name="13">6</col>
+			<col name="30">5</col>
+			<col name="31">5</col>
+			<col name="label">v2</col>
 			<col name="2">6</col>
 			<col name="6">5</col>
-			<col name="label">v2</col>
 			<col name="15">12</col>
 			<col name="19">7</col>
 			<col name="20">2</col>
 			<col name="21">2</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">8</col>
+			<col name="2">7</col>
+			<col name="3">6</col>
+			<col name="5">5</col>
+			<col name="6">4</col>
+			<col name="7">3</col>
+			<col name="8">2</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">6</col>
+			<col name="2">5</col>
+			<col name="3">4</col>
+			<col name="5">3</col>
+			<col name="6">2</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
 		</row>
 	</result>
 </results>

--- a/tests/Integration/Importers/expected/CustomDimensions_mobileApp_old.xml
+++ b/tests/Integration/Importers/expected/CustomDimensions_mobileApp_old.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result record="CustomDimensions_Dimension2">
+		<row>
+			<col name="12">10</col>
+			<col name="13">10</col>
+			<col name="30">8</col>
+			<col name="31">8</col>
+			<col name="label">v1</col>
+			<col name="2">19</col>
+			<col name="6">17</col>
+			<col name="15">25</col>
+			<col name="19">10</col>
+			<col name="20">7</col>
+			<col name="21">4</col>
+		</row>
+		<row>
+			<col name="12">6</col>
+			<col name="13">6</col>
+			<col name="30">5</col>
+			<col name="31">5</col>
+			<col name="label">v2</col>
+			<col name="2">6</col>
+			<col name="6">5</col>
+			<col name="15">12</col>
+			<col name="19">7</col>
+			<col name="20">2</col>
+			<col name="21">2</col>
+		</row>
+	</result>
+	<result record="CustomDimensions_Dimension1">
+		<row>
+			<col name="1">8</col>
+			<col name="2">7</col>
+			<col name="3">6</col>
+			<col name="5">5</col>
+			<col name="6">4</col>
+			<col name="7">3</col>
+			<col name="8">2</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 1</col>
+		</row>
+		<row>
+			<col name="1">6</col>
+			<col name="2">5</col>
+			<col name="3">4</col>
+			<col name="5">3</col>
+			<col name="6">2</col>
+			<col name="7">1</col>
+			<col name="8">1</col>
+			<col name="9">1</col>
+			<col name="10">
+			</col>
+			<col name="label">value 2</col>
+		</row>
+	</result>
+</results>

--- a/tests/System/ImportTest.php
+++ b/tests/System/ImportTest.php
@@ -54,6 +54,11 @@ class ImportTest extends SystemTestCase
         if (version_compare(Version::VERSION, '4.6.0', '<')) {
             $apiNotToTest[] = 'DevicesDetection.getBrowserEngines';
         }
+
+        if (version_compare(Version::VERSION, '5.1.0-rc1') <= 0) {
+            $apiNotToTest[] = 'CustomDimensions.getConfiguredCustomDimensions';
+        }
+
         return [
             [$apiToTest, ['idSite' => self::$fixture->idSite, 'date' => self::$fixture->dateTime, 'periods' => ['day', 'week', 'month', 'year'], 'apiNotToCall' => $apiNotToTest]],
             [$secondaryApiToTest, ['idSite' => self::$fixture->idSite, 'date' => self::$fixture->dateTime, 'periods' => ['day', 'week', 'month']]],

--- a/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
+++ b/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
@@ -34,17 +34,6 @@
 		<case_sensitive>1</case_sensitive>
 	</row>
 	<row>
-		<idcustomdimension>6</idcustomdimension>
-		<idsite>1</idsite>
-		<name>recommendedLevel</name>
-		<index>4</index>
-		<scope>action</scope>
-		<active>1</active>
-		<extractions>
-		</extractions>
-		<case_sensitive>1</case_sensitive>
-	</row>
-	<row>
 		<idcustomdimension>4</idcustomdimension>
 		<idsite>1</idsite>
 		<name>userType</name>
@@ -61,6 +50,17 @@
 		<name>happinessLevel</name>
 		<index>2</index>
 		<scope>visit</scope>
+		<active>1</active>
+		<extractions>
+		</extractions>
+		<case_sensitive>1</case_sensitive>
+	</row>
+	<row>
+		<idcustomdimension>6</idcustomdimension>
+		<idsite>1</idsite>
+		<name>recommendedLevel</name>
+		<index>4</index>
+		<scope>action</scope>
 		<active>1</active>
 		<extractions>
 		</extractions>

--- a/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
+++ b/tests/System/expected/test___CustomDimensions.getConfiguredCustomDimensions.xml
@@ -34,6 +34,17 @@
 		<case_sensitive>1</case_sensitive>
 	</row>
 	<row>
+		<idcustomdimension>6</idcustomdimension>
+		<idsite>1</idsite>
+		<name>recommendedLevel</name>
+		<index>4</index>
+		<scope>action</scope>
+		<active>1</active>
+		<extractions>
+		</extractions>
+		<case_sensitive>1</case_sensitive>
+	</row>
+	<row>
 		<idcustomdimension>4</idcustomdimension>
 		<idsite>1</idsite>
 		<name>userType</name>
@@ -50,17 +61,6 @@
 		<name>happinessLevel</name>
 		<index>2</index>
 		<scope>visit</scope>
-		<active>1</active>
-		<extractions>
-		</extractions>
-		<case_sensitive>1</case_sensitive>
-	</row>
-	<row>
-		<idcustomdimension>6</idcustomdimension>
-		<idsite>1</idsite>
-		<name>recommendedLevel</name>
-		<index>4</index>
-		<scope>action</scope>
 		<active>1</active>
 		<extractions>
 		</extractions>


### PR DESCRIPTION
### Description:

Change db backoff due to rate limit per site instead of setting it globally
Fixes: #PG-2588

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
