### PR TITLE
Adding new events to be tracked by ActivityLog

### DIFF
--- a/Commands/ImportGA4Reports.php
+++ b/Commands/ImportGA4Reports.php
@@ -12,6 +12,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Option;
+use Piwik\Piwik;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\GoogleAnalyticsImporter\CannotProcessImportException;
@@ -172,6 +173,15 @@ class ImportGA4Reports extends ConsoleCommand
                 $output->writeln(LogToSingleFileProcessor::$cliOutputPrefix . "Failed to import property entities, aborting.");
                 return self::FAILURE;
             }
+
+            // Record the correct activity for the command. It's either a new import or a resumed import
+            $status = $importStatus->getImportStatus($idSite);
+            if ($createdSiteInCommand) {
+                Piwik::postEvent('GoogleAnalyticsImporter.startImportGA4.end', [$status]);
+            } else {
+                Piwik::postEvent('GoogleAnalyticsImporter.resumeImport.end', [$status]);
+            }
+
             $dateRangesToReImport = empty($status['reimport_ranges']) ? [] : $status['reimport_ranges'];
             $dateRangesToReImport = array_map(function ($d) {
                 return [Date::factory($d[0]), Date::factory($d[1])];


### PR DESCRIPTION
### Description:

This PR triggers some new events that can be tracked by other plugins. This is mainly so that we can record the events using the ActivityLog plugin.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
