### PR TITLE
Improved redirect URI check for MWP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+# 5.1.3 - 2025-05-28
+- Added fallback URI for valid redirect URI check to solve issues with some Matomo for WordPress install
+
 # 5.1.2 - 2025-03-17
 - Started importing region data as the region dimension is now available in the API request
 

--- a/Google/Authorization.php
+++ b/Google/Authorization.php
@@ -137,7 +137,11 @@ class Authorization
     private function getValidUri($uris)
     {
         $validUri = Url::getCurrentUrlWithoutQueryString() . '?module=GoogleAnalyticsImporter&action=processAuthCode';
-        $validUriFallback = SettingsPiwik::getPiwikUrl() . 'index.php?module=GoogleAnalyticsImporter&action=processAuthCode'; // Some MWP installs was not working as expected when using Url::getCurrentUrlWithoutQueryString()
+        $settingURL = SettingsPiwik::getPiwikUrl();
+        if (stripos($settingURL, 'index.php') === false) {
+            $settingURL .= 'index.php';
+        }
+        $validUriFallback = $settingURL . '?module=GoogleAnalyticsImporter&action=processAuthCode'; // Some MWP installs was not working as expected when using Url::getCurrentUrlWithoutQueryString()
         foreach ($uris as $uri) {
             if (stripos($uri, $validUri) !== \false || stripos($uri, $validUriFallback) !== \false) {
                 return $uri;

--- a/Google/Authorization.php
+++ b/Google/Authorization.php
@@ -137,7 +137,7 @@ class Authorization
     private function getValidUri($uris)
     {
         $validUri = Url::getCurrentUrlWithoutQueryString() . '?module=GoogleAnalyticsImporter&action=processAuthCode';
-        $validUriFallback = SettingsPiwik::getPiwikUrl() . '?module=GoogleAnalyticsImporter&action=processAuthCode'; // Some MWP installs was not working as expected when using Url::getCurrentUrlWithoutQueryString()
+        $validUriFallback = SettingsPiwik::getPiwikUrl() . 'index.php?module=GoogleAnalyticsImporter&action=processAuthCode'; // Some MWP installs was not working as expected when using Url::getCurrentUrlWithoutQueryString()
         foreach ($uris as $uri) {
             if (stripos($uri, $validUri) !== \false || stripos($uri, $validUriFallback) !== \false) {
                 return $uri;

--- a/Google/Authorization.php
+++ b/Google/Authorization.php
@@ -15,6 +15,7 @@ use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\SettingsPiwik;
 use Piwik\Url;
 
 class Authorization
@@ -136,8 +137,9 @@ class Authorization
     private function getValidUri($uris)
     {
         $validUri = Url::getCurrentUrlWithoutQueryString() . '?module=GoogleAnalyticsImporter&action=processAuthCode';
+        $validUriFallback = SettingsPiwik::getPiwikUrl() . '?module=GoogleAnalyticsImporter&action=processAuthCode'; // Some MWP installs was not working as expected when using Url::getCurrentUrlWithoutQueryString()
         foreach ($uris as $uri) {
-            if (stripos($uri, $validUri) !== \FALSE) {
+            if (stripos($uri, $validUri) !== \false || stripos($uri, $validUriFallback) !== \false) {
                 return $uri;
             }
         }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "GoogleAnalyticsImporter",
     "description": "Import reports from a Google Analytics account into Matomo.",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-rc5,<6.0.0-b1"


### PR DESCRIPTION
## Description
We received a bug report from some of our Matomo for WordPress customer that, they are getting an error when trying to import keywords for Google via SEKP plugin, since this plugin uses the same logic we have updated the function here too.

## Issue No

-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?