### PR TITLE
PG-4656 test with matomo5_[max|min]_php [ignore_release]

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -1,7 +1,7 @@
 # Action for running tests
 # This file has been automatically created.
 # To recreate it you can run this command
-# ./console generate:test-action --plugin="GoogleAnalyticsImporter" --php-versions="7.2,8.4" --dependent-plugins="matomo-org/plugin-MarketingCampaignsReporting innocraft/plugin-Funnels" --schedule-cron="10 3 * * 6"
+# ./console generate:test-action --plugin="GoogleAnalyticsImporter" --php-versions="matomo5_min_php,matomo5_max_php" --dependent-plugins="matomo-org/plugin-MarketingCampaignsReporting innocraft/plugin-Funnels" --schedule-cron="10 3 * * 6"
 
 name: Plugin GoogleAnalyticsImporter Tests
 
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '8.4' ]
+        php: [ 'matomo5_min_php', 'matomo5_max_php' ]
         target: ['minimum_required_matomo', 'maximum_supported_matomo']
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
           test-type: 'PluginTests'
           matomo-test-branch: ${{ matrix.target }}
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
-          upload-artifacts: ${{ matrix.php == '7.2' && matrix.target == 'maximum_supported_matomo' }}
+          upload-artifacts: ${{ matrix.php == 'matomo5_min_php' && matrix.target == 'maximum_supported_matomo' }}
           dependent-plugins: 'matomo-org/plugin-MarketingCampaignsReporting innocraft/plugin-Funnels'
           github-token: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
   UI:
@@ -70,7 +70,7 @@ jobs:
           plugin-name: 'GoogleAnalyticsImporter'
           matomo-test-branch: 'maximum_supported_matomo'
           test-type: 'UI'
-          php-version: '7.2'
+          php-version: 'matomo5_min_php'
           node-version: '16'
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
           upload-artifacts: true


### PR DESCRIPTION
Updating the matomo-tests workflow to use shared min/max PHP versions so that we don't have to create a new PR every time we want to support a new PHP version for Matomo and all plugins.