### PR TITLE
Add PHPStan setup at level 1, PG-4897 [no_release]

### DIFF
--- a/.git-hooks-matomo/pre-push
+++ b/.git-hooks-matomo/pre-push
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+
+
+
+### Check we're running in the context of a plugin and get helpful dir variables ###
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+echo "Running pre-commit hook in repo: $REPO_DIR"
+
+if [[ "$REPO_DIR" =~ /plugins/(.*) ]]; then
+    PLUGIN_PATH="plugins/${BASH_REMATCH[1]}/"
+else
+    echo "Not a plugin, not running any further checks"
+    exit 1
+fi
+MATOMO_DIR=$(echo "$REPO_DIR" | sed -E 's|/plugins/.*$||')
+
+
+
+### Figure out how to run PHPStan - ddev or not. ###
+
+COMMAND=""
+# Use local PHP if setup
+if command -v php >/dev/null 2>&1 && [ -f "${MATOMO_DIR}/vendor/bin/phpstan" ]; then
+    COMMAND="${MATOMO_DIR}/vendor/bin/phpstan"
+    PLUGIN_PATH=''
+elif command -v ddev >/dev/null 2>&1; then
+  # Use ddev if setup (overridding local setup)
+  if [ -d "$MATOMO_DIR/.ddev" ]; then
+    cd "$MATOMO_DIR" || exit 1
+    if ddev status 2>&1 > /dev/null; then
+      COMMAND="ddev exec phpstan"
+    fi
+  fi
+fi
+# If no command, exit
+if [[ -z "$COMMAND" ]]; then
+  echo "No way to run phpstan found."
+  exit 1
+fi
+
+
+
+# Basic setup
+cd "$REPO_DIR"
+STATUS=0
+
+
+
+
+### Run PHPStan on newly created files. ###
+
+PHPSTAN_CREATED_CONFIG=phpstan/phpstan.created.neon
+MAIN_BRANCH='5.x-dev'
+if [[ -f "$PHPSTAN_CREATED_CONFIG" ]]; then
+  CHANGED_FILES=$(git diff --name-only ${MAIN_BRANCH} --diff-filter=A | grep '\.php$' || true)
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "No created PHP files"
+  else
+    echo "Running PHPstan at a very high level on new files"
+    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
+    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_CREATED_CONFIG} || STATUS=1
+  fi
+fi
+
+
+
+### Run PHPStan on modified files. ###
+PHPSTAN_MODIFIED_CONFIG=phpstan/phpstan.modified.neon
+if [[ -f "$PHPSTAN_MODIFIED_CONFIG" ]]; then
+  CHANGED_FILES=$(git diff --name-only ${MAIN_BRANCH} --diff-filter=CM | grep '\.php$' || true)
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "No changed PHP files"
+  else
+    echo "Running PHPstan on modified files"
+    CHANGED_FILES=`echo "$CHANGED_FILES" | sed -e 's/^\(.*\)$/"\1"/' | xargs -I{} echo "${PLUGIN_PATH}{}"`
+    echo "$CHANGED_FILES" | xargs $COMMAND analyse -c ${PLUGIN_PATH}${PHPSTAN_MODIFIED_CONFIG} || STATUS=1
+  fi
+fi
+
+# Don't bother running the full check, as we check changes files already, and
+# can assume that the unchanged files don't need rechecking.
+#
+# Github will check this anyway.
+#
+# PHPSTAN_BASE_CONFIG=phpstan.neon
+# if [[ -f "$PHPSTAN_BASE_CONFIG" ]]; then
+#     echo "Running PHPstan at a base level on all plugin files"
+#   $COMMAND analyse -c ${PLUGIN_PATH}/${PHPSTAN_BASE_CONFIG} || STATUS=1
+# fi
+
+exit $STATUS

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,89 @@
+name: PHPStan check
+
+on: pull_request
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: read
+
+env:
+  PLUGIN_NAME: GoogleAnalyticsImporter
+  DEPENDENT_PLUGINS: matomo-org/plugin-MarketingCampaignsReporting innocraft/plugin-Funnels innocraft/plugin-ConnectAccounts
+
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          # 8.2 rather than 7.2: the ConnectAccounts dependency uses PHP 8
+          # attribute syntax, which fatals when loaded on 7.2. The analysis
+          # level stays PHP 7.2 via phpVersion in phpstan.neon.
+          php-version: '8.2'
+
+      - name: Check out github-action-tests repository
+        uses: actions/checkout@v4
+        with:
+          repository: matomo-org/github-action-tests
+          ref: main
+          path: github-action-tests
+          persist-credentials: false
+
+      - name: checkout matomo for plugin builds
+        shell: bash
+        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_matomo.sh
+        env:
+          PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+          ACTION_PATH: ${{ github.workspace }}/github-action-tests
+          MATOMO_TEST_TARGET: maximum_supported_matomo
+
+      - name: prepare setup
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/matomo
+          echo -e "composer install"
+          composer install --ignore-platform-reqs
+
+      - name: checkout additional plugins
+        if: ${{ env.DEPENDENT_PLUGINS != '' }}
+        shell: bash
+        working-directory: ${{ github.workspace }}/matomo
+        run: ${{ github.workspace }}/github-action-tests/scripts/bash/checkout_dependent_plugins.sh
+
+        env:
+          DEPENDENT_PLUGINS: ${{ env.DEPENDENT_PLUGINS }}
+          GITHUB_USER_TOKEN: ${{ secrets.TESTS_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/phpstan # same as in phpstan.neon
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
+
+      - name: PHPStan whole repo
+        id: phpstan-all
+        run: cd ${{ github.workspace }}/matomo && composer run phpstan -- -vvv -c plugins/${{ env.PLUGIN_NAME }}/phpstan.neon
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: /tmp/phpstan # same as in phpstan.neon
+          key: "phpstan-result-cache-${{ github.run_id }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+# 5.2.1 - 2026-08-03
+- Added PHPStan static analysis (CI check and pre-push hook)
+- Fixed an error that could hide the real failure reason when starting a GA4 import fails
+
 # 5.2.0 - 2026-07-20
 - Added code to encrypt sensitive information in the database
 

--- a/Commands/ImportGA4Reports.php
+++ b/Commands/ImportGA4Reports.php
@@ -88,7 +88,7 @@ class ImportGA4Reports extends ConsoleCommand
         }
         $type = $isMobileApp ? \Piwik\Plugins\MobileAppMeasurable\Type::ID : Type::ID;
         $idSite = $this->getIdSite();
-        LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite, $output);
+        LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite);
         /** @var ImportStatus $importStatus */
         $importStatus = StaticContainer::get(ImportStatus::class);
         $canProcessNow = $this->checkIfCanProcess($idSite);

--- a/Commands/ImportReports.php
+++ b/Commands/ImportReports.php
@@ -81,7 +81,7 @@ class ImportReports extends ConsoleCommand
         }
         $type = $isMobileApp ? \Piwik\Plugins\MobileAppMeasurable\Type::ID : Type::ID;
         $idSite = $this->getIdSite();
-        LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite, $output);
+        LogToSingleFileProcessor::handleLogToSingleFileInCliCommand($idSite);
         $canProcessNow = $this->checkIfCanProcess($idSite);
         /** @var ImportStatus $importStatus */
         $importStatus = StaticContainer::get(ImportStatus::class);

--- a/Controller.php
+++ b/Controller.php
@@ -194,8 +194,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     /**
      * Processes the response from google oauth service
      *
-     * @return string
-     * @throws \Exception
+     * @return string|null
      */
     public function processAuthCode()
     {
@@ -346,13 +345,13 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $isVerboseLoggingEnabled = Common::getRequestVar('isVerboseLoggingEnabled', 0, $type = 'int') == 1;
             $forceCustomDimensionSlotCheck = Common::getRequestVar('forceCustomDimensionSlotCheck', 1, $type = 'int') == 1;
             $idSite = $importer->makeSite($propertyId, $timezone, $isMobileApp ? Type::ID : \Piwik\Plugins\WebsiteMeasurable\Type::ID, $extraCustomDimensions, $forceCustomDimensionSlotCheck, $streamIds);
+            /** @var ImportStatus $importStatus */
+            $importStatus = StaticContainer::get(\Piwik\Plugins\GoogleAnalyticsImporter\ImportStatus::class);
             try {
                 if (empty($idSite)) {
                     throw new \Exception("Unable to import site entity.");
                     // sanity check
                 }
-                /** @var ImportStatus $importStatus */
-                $importStatus = StaticContainer::get(\Piwik\Plugins\GoogleAnalyticsImporter\ImportStatus::class);
                 if (!empty($startDate) || !empty($endDate)) {
                     // we set the last imported date to one day before the start date
                     $importStatus->setImportDateRange($idSite, $startDate ?: null, $endDate ?: null);

--- a/Google/GoogleAnalyticsGA4QueryService.php
+++ b/Google/GoogleAnalyticsGA4QueryService.php
@@ -154,7 +154,7 @@ class GoogleAnalyticsGA4QueryService
             try {
                 $this->issuePointlessMysqlQuery();
                 $result = $this->gaClient->runReport($request);
-                if (empty($result)) {
+                if ($result === null) {
                     ++$attempts;
                     $this->backOff($skipReAttempt);
                     $this->logger->info("Google Analytics API returned null for some reason, trying again...");

--- a/GoogleAnalyticsImporter.php
+++ b/GoogleAnalyticsImporter.php
@@ -277,7 +277,7 @@ class GoogleAnalyticsImporter extends \Piwik\Plugin
     public function configureImportedReportView(ViewDataTable $view)
     {
         $table = $view->getDataTable();
-        if (empty($table) || !$table instanceof DataTable) {
+        if (!$table instanceof DataTable) {
             return;
         }
         $period = Common::getRequestVar('period', \false);

--- a/Importer.php
+++ b/Importer.php
@@ -9,7 +9,7 @@
 
 namespace Piwik\Plugins\GoogleAnalyticsImporter;
 
-use Matomo\Dependencies\GoogleAnalyticsImporter\Google_Service_Analytics_Goal;
+use Matomo\Dependencies\GoogleAnalyticsImporter\Google\Service\Analytics\Goal as Google_Service_Analytics_Goal;
 use Piwik\API\Request;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\ArchiveProcessor\Parameters;
@@ -259,6 +259,7 @@ class Importer
                 $this->logger->info("Extra custom dimension '{gaCustomDimension}' entity already imported.", ['gaCustomDimension' => $extraEntry['gaDimension']]);
                 continue;
             }
+            $idDimension = null;
             try {
                 $idDimension = CustomDimensionsAPI::getInstance()->configureNewCustomDimension($idSite, $extraEntry['gaDimension'], $extraEntry['dimensionScope'], $active = \true);
             } catch (\Exception $ex) {

--- a/ImporterGA4.php
+++ b/ImporterGA4.php
@@ -311,6 +311,7 @@ class ImporterGA4
                 $this->logger->info("Extra custom dimension '{gaCustomDimension}' entity already imported.", ['gaCustomDimension' => $extraEntry['gaDimension']]);
                 continue;
             }
+            $idDimension = null;
             try {
                 $idDimension = CustomDimensionsAPI::getInstance()->configureNewCustomDimension($idSite, $extraEntry['gaDimension'], $extraEntry['dimensionScope'], $active = \true);
             } catch (\Exception $ex) {

--- a/Importers/MarketingCampaignsReporting/RecordImporterGA4.php
+++ b/Importers/MarketingCampaignsReporting/RecordImporterGA4.php
@@ -27,7 +27,7 @@ class RecordImporterGA4 extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImp
     protected $columnToSortByBeforeTruncation;
     protected $maximumRowsInDataTable;
     protected $maximumRowsInSubDataTable;
-    public function __construct(GoogleAnalyticsGA4QueryService $gaQuery, $idSite, LoggerInterface $logger, $segmentToApply = null)
+    public function __construct(GoogleAnalyticsGA4QueryService $gaQuery, $idSite, LoggerInterface $logger)
     {
         parent::__construct($gaQuery, $idSite, $logger);
         $this->columnToSortByBeforeTruncation = Metrics::INDEX_NB_VISITS;

--- a/Importers/Referrers/RecordImporter.php
+++ b/Importers/Referrers/RecordImporter.php
@@ -77,7 +77,6 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImport
         $this->insertRecord(Archiver::REFERRER_TYPE_RECORD_NAME, $this->referrerTypeRecord, $this->maximumRowsInDataTableLevelZero, $this->maximumRowsInSubDataTable, $this->columnToSortByBeforeTruncation);
         Common::destroy($this->referrerTypeRecord);
         $this->referrerTypeRecord = null;
-        unset($blob);
         unset($this->campaignKeywords);
         // numeric records
         $numericRecords = array(Archiver::METRIC_DISTINCT_SEARCH_ENGINE_RECORD_NAME => $distinctSearchEngines, Archiver::METRIC_DISTINCT_SOCIAL_NETWORK_RECORD_NAME => $distinctSocialNetworks, Archiver::METRIC_DISTINCT_KEYWORD_RECORD_NAME => $distinctKeywords, Archiver::METRIC_DISTINCT_CAMPAIGN_RECORD_NAME => $distinctCampaigns, Archiver::METRIC_DISTINCT_WEBSITE_RECORD_NAME => $distinctWebsites);

--- a/Importers/Referrers/RecordImporterGA4.php
+++ b/Importers/Referrers/RecordImporterGA4.php
@@ -77,7 +77,6 @@ class RecordImporterGA4 extends \Piwik\Plugins\GoogleAnalyticsImporter\RecordImp
         $this->insertRecord(Archiver::REFERRER_TYPE_RECORD_NAME, $this->referrerTypeRecord, $this->maximumRowsInDataTableLevelZero, $this->maximumRowsInSubDataTable, $this->columnToSortByBeforeTruncation);
         Common::destroy($this->referrerTypeRecord);
         $this->referrerTypeRecord = null;
-        unset($blob);
         unset($this->campaignKeywords);
         // numeric records
         $numericRecords = array(

--- a/Importers/Resolution/RecordImporter.php
+++ b/Importers/Resolution/RecordImporter.php
@@ -47,7 +47,6 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\Importers\De
         }
         Common::destroy($table);
         $this->insertRecord(Archiver::CONFIGURATION_RECORD_NAME, $record, $this->getStandardMaximumRows(), null, Metrics::INDEX_NB_VISITS);
-        unset($blob);
         Common::destroy($record);
     }
     private function queryScreenResolution(Date $day)
@@ -64,7 +63,6 @@ class RecordImporter extends \Piwik\Plugins\GoogleAnalyticsImporter\Importers\De
         }
         Common::destroy($table);
         $this->insertRecord(Archiver::RESOLUTION_RECORD_NAME, $record, $this->getStandardMaximumRows(), null, Metrics::INDEX_NB_VISITS);
-        unset($blob);
         Common::destroy($record);
     }
 }

--- a/Importers/Resolution/RecordImporterGA4.php
+++ b/Importers/Resolution/RecordImporterGA4.php
@@ -47,7 +47,6 @@ class RecordImporterGA4 extends \Piwik\Plugins\GoogleAnalyticsImporter\Importers
         }
         Common::destroy($table);
         $this->insertRecord(Archiver::CONFIGURATION_RECORD_NAME, $record, $this->getStandardMaximumRows(), null, Metrics::INDEX_NB_VISITS);
-        unset($blob);
         Common::destroy($record);
     }
     private function queryScreenResolution(Date $day)
@@ -64,7 +63,6 @@ class RecordImporterGA4 extends \Piwik\Plugins\GoogleAnalyticsImporter\Importers
         }
         Common::destroy($table);
         $this->insertRecord(Archiver::RESOLUTION_RECORD_NAME, $record, $this->getStandardMaximumRows(), null, Metrics::INDEX_NB_VISITS);
-        unset($blob);
         Common::destroy($record);
     }
 }

--- a/Input/EndDate.php
+++ b/Input/EndDate.php
@@ -82,9 +82,6 @@ class EndDate
     }
     private function readConfigForcedMaxEndDate(Config $config)
     {
-        if (empty($config)) {
-            return null;
-        }
         $configSection = $config->GoogleAnalyticsImporter;
         $maxEndDate = !empty($configSection[self::CONFIG_NAME]) ? $configSection[self::CONFIG_NAME] : null;
         if (!empty($maxEndDate)) {

--- a/RecordImporter.php
+++ b/RecordImporter.php
@@ -154,6 +154,7 @@ abstract class RecordImporter
     protected function getGapLabel(array $gap, $value)
     {
         $range = null;
+        $bounds = [];
         foreach ($gap as $bounds) {
             $upperBound = end($bounds);
             if ($value <= $upperBound) {

--- a/RecordImporterGA4.php
+++ b/RecordImporterGA4.php
@@ -162,6 +162,7 @@ abstract class RecordImporterGA4
     protected function getGapLabel(array $gap, $value)
     {
         $range = null;
+        $bounds = [];
         foreach ($gap as $bounds) {
             $upperBound = end($bounds);
             if ($value <= $upperBound) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,31 @@
+parameters:
+    level: 1
+    phpVersion: 70200
+    tmpDir: /tmp/phpstan/GoogleAnalyticsImporter/main
+    paths:
+        - .
+    excludePaths:
+        analyseAndScan:
+            - tests/*
+            - github-action-tests/
+            - scoper.inc.php
+        # still scanned so the prefixed Google classes are discovered even
+        # when the Matomo bootstrap cannot load plugin autoloaders (e.g. CI)
+        analyse:
+            - vendor/
+    ignoreErrors:
+        # WpMatomo and get_option exist only when running inside Matomo for WordPress
+        - '#^Instantiated class WpMatomo\\Site not found\.$#'
+        - '#^Access to constant OPTION_NAME_INSTALL_DATE on an unknown class WpMatomo\\Installer\.$#'
+        - '#^Function get_option not found\.$#'
+    bootstrapFiles:
+        - ../../bootstrap-phpstan.php
+    universalObjectCratesClasses:
+        - Piwik\Config
+        - Piwik\View
+        - Piwik\ViewDataTable\Config
+    scanDirectories:
+        # ../../ does not actually seem to give us anything
+        # that ../plugins/ does not, but including it for
+        # completeness.  It does not seem to slow down performance.
+        - ../../

--- a/phpstan/phpstan.created.neon
+++ b/phpstan/phpstan.created.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../phpstan.neon
+parameters:
+    level: 5
+    tmpDir: /tmp/phpstan/GoogleAnalyticsImporter/created

--- a/phpstan/phpstan.modified.neon
+++ b/phpstan/phpstan.modified.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../phpstan.neon
+parameters:
+    level: 5
+    tmpDir: /tmp/phpstan/GoogleAnalyticsImporter/modified

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "GoogleAnalyticsImporter",
     "description": "Import reports from a Google Analytics account into Matomo.",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "theme": false,
     "require": {
         "matomo": ">=5.0.0-rc5,<6.0.0-b1"

--- a/tests/Integration/ControllerTest.php
+++ b/tests/Integration/ControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GoogleAnalyticsImporter\tests\Integration;
+
+use Matomo\Dependencies\GoogleAnalyticsImporter\Google\Analytics\Admin\V1alpha\AnalyticsAdminServiceClient;
+use Matomo\Dependencies\GoogleAnalyticsImporter\Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
+use Piwik\Nonce;
+use Piwik\Plugins\GoogleAnalyticsImporter\Controller;
+use Piwik\Plugins\GoogleAnalyticsImporter\Google\AuthorizationGA4;
+use Piwik\Plugins\GoogleAnalyticsImporter\ImporterGA4;
+use Piwik\Plugins\GoogleAnalyticsImporter\ImportStatus;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group GoogleAnalyticsImporter
+ * @group GoogleAnalyticsImporter_Integration
+ */
+class ControllerTest extends IntegrationTestCase
+{
+    private $originalGet;
+
+    /**
+     * @var ImportStatus|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $importStatus;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->originalGet = $_GET;
+        FakeAccess::clearAccess(true);
+    }
+
+    public function tearDown(): void
+    {
+        $_GET = $this->originalGet;
+        FakeAccess::clearAccess();
+        parent::tearDown();
+    }
+
+    public function test_startImportGA4_recordsTheOriginalErrorWhenTheImportFailsToStart()
+    {
+        $_GET = [
+            'nonce' => Nonce::getNonce('GoogleAnalyticsImporter.startImportNonce'),
+            'propertyId' => 'properties/12345',
+        ];
+
+        $this->importStatus
+            ->expects(self::once())
+            ->method('erroredImport')
+            ->with(self::anything(), 'Unable to import site entity.');
+
+        ob_start();
+        try {
+            (new Controller())->startImportGA4();
+        } finally {
+            $output = ob_get_clean();
+        }
+
+        self::assertStringNotContainsString('"result":"ok"', (string) $output);
+    }
+
+    public function provideContainerConfig()
+    {
+        $this->importStatus = $this->createMock(ImportStatus::class);
+
+        $importer = $this->createMock(ImporterGA4::class);
+        $importer->method('makeSite')->willReturn(null);
+
+        $authorization = $this->createMock(AuthorizationGA4::class);
+        $authorization->method('getClient')->willReturn($this->createMock(BetaAnalyticsDataClient::class));
+        $authorization->method('getAdminClient')->willReturn($this->createMock(AnalyticsAdminServiceClient::class));
+
+        return [
+            'Piwik\Access' => new FakeAccess(),
+            ImportStatus::class => $this->importStatus,
+            ImporterGA4::class => $importer,
+            AuthorizationGA4::class => $authorization,
+        ];
+    }
+}


### PR DESCRIPTION
## Description
Sets up PHPStan static analysis for this plugin, following the setup already used by other Matomo plugins (e.g. plugin-Slack): a `phpstan.neon` at level 1, a GitHub Actions check that runs on every pull request, and an optional pre-push git hook that analyses changed files at a stricter level (enable it with `git config core.hooksPath .git-hooks-matomo`).

Includes the small code fixes needed for a clean level 1 run. One of them fixes a real issue: when starting a GA4 import failed early, the error handler itself could fail on an unassigned variable and hide the real failure reason from the user. The remaining fixes are behaviour-neutral (dead code removal, variable initialisation, an unused parameter, a class name that only existed as a runtime alias).

The CI job checks out the dependent MarketingCampaignsReporting and Funnels plugins so their classes referenced by the importers can be resolved.

## Issue No
PG-4897

## Steps to Replicate the Issue
1. Run PHPStan for this plugin in a Matomo checkout.
2. Expected: static analysis runs with a plugin-specific configuration, as for other plugins.
3. Actual: no PHPStan configuration existed for this plugin.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?

