### PR TITLE
Add escapeshell args for matomo domain, #AS-685

### DIFF
--- a/Importer.php
+++ b/Importer.php
@@ -288,7 +288,7 @@ class Importer
         $command = "php " . PIWIK_INCLUDE_PATH . '/console';
         $domain = Config::getInstance()->getConfigHostnameIfSet();
         if (!empty($domain)) {
-            $command .= ' --matomo-domain=' . $domain;
+            $command .= ' --matomo-domain=' . escapeshellarg($domain);
         }
         $command .= ' customvariables:set-max-custom-variables ' . $numCustomVarSlots;
         passthru($command);

--- a/ImporterGA4.php
+++ b/ImporterGA4.php
@@ -340,7 +340,7 @@ class ImporterGA4
         $command = "php " . PIWIK_INCLUDE_PATH . '/console';
         $domain = Config::getInstance()->getConfigHostnameIfSet();
         if (!empty($domain)) {
-            $command .= ' --matomo-domain=' . $domain;
+            $command .= ' --matomo-domain=' . escapeshellarg($domain);
         }
         $command .= ' customvariables:set-max-custom-variables ' . $numCustomVarSlots;
         passthru($command);


### PR DESCRIPTION
## Description
Add escapeshell args for matomo domain, #AS-685

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
