### PR TITLE
Port the escaped Matomo domain to 6.x, #AS-685

### DIFF
--- a/Importer.php
+++ b/Importer.php
@@ -288,7 +288,7 @@ class Importer
         $command = "php " . PIWIK_INCLUDE_PATH . '/console';
         $domain = Config::getInstance()->getConfigHostnameIfSet();
         if (!empty($domain)) {
-            $command .= ' --matomo-domain=' . $domain;
+            $command .= ' --matomo-domain=' . escapeshellarg($domain);
         }
         $command .= ' customvariables:set-max-custom-variables ' . $numCustomVarSlots;
         passthru($command);

--- a/ImporterGA4.php
+++ b/ImporterGA4.php
@@ -340,7 +340,7 @@ class ImporterGA4
         $command = "php " . PIWIK_INCLUDE_PATH . '/console';
         $domain = Config::getInstance()->getConfigHostnameIfSet();
         if (!empty($domain)) {
-            $command .= ' --matomo-domain=' . $domain;
+            $command .= ' --matomo-domain=' . escapeshellarg($domain);
         }
         $command .= ' customvariables:set-max-custom-variables ' . $numCustomVarSlots;
         passthru($command);


### PR DESCRIPTION
## Description

Forward-ports the AS-685 fix, which escapes the Matomo domain before it is appended to the import command. It landed on `5.x-dev` on 19 August and has no equivalent on the 6.x line, so Matomo 6 would have shipped without it.

Cherry-picked with `-x`, so it keeps a reference to the original commit. Two lines, one in `Importer.php` and one in `ImporterGA4.php`.

Based on `6.x-dev` rather than `prepare6x`: unlike the dependency regeneration in #644, this does not depend on the PHP floor that #639 introduces, and #639 does not touch either file, so it can be reviewed and merged on its own rather than waiting behind the migration.

No version bump or changelog entry, matching the original commit — and the `6.0.0` entry this would otherwise belong under does not exist on `6.x-dev` yet, since it arrives with #639.

## Issue No

AS-685, on the 6.x line.

## Steps to Replicate the Issue

1. Compare `Importer.php` and `ImporterGA4.php` between `5.x-dev` and `6.x-dev`.
2. Expected: the Matomo domain is escaped before being appended to the command on both lines.
3. Actual, before this PR: only `5.x-dev` escapes it.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
